### PR TITLE
feat: add yieldable and tracked

### DIFF
--- a/.changeset/honest-mangos-throw.md
+++ b/.changeset/honest-mangos-throw.md
@@ -1,0 +1,5 @@
+---
+"effect-boxes": minor
+---
+
+make Box yieldable and add tracked method to Renderer

--- a/.changeset/ripe-wombats-smell.md
+++ b/.changeset/ripe-wombats-smell.md
@@ -1,5 +1,5 @@
 ---
-"effect-boxes": major
+"effect-boxes": minor
 ---
 
 publish on npm

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
 # Finder (MacOS) folder config
 .DS_Store
+
+# References
+.reference

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -618,6 +618,19 @@ rg --files -g "*.ts"
 rg --files -g "*.test.ts"
 ```
 
+## Local Source References
+
+When answering questions about Effect, search these
+cloned source repos first. When updating dependencies, pull the latest
+commits in these repos to ensure the LLM references current code:
+
+- `.reference/effect/`
+
+If any of the folders are missing (they are git ignored), clone them into
+`reference/`:
+
+- `https://github.com/Effect-TS/effect-smol.git` -> `.reference/effect/`
+
 ---
 
 _This document is a living guide. Update it as the project evolves and new

--- a/src/Box.ts
+++ b/src/Box.ts
@@ -121,7 +121,8 @@ export interface Box<A = never>
   extends Pipeable,
     Equal.Equal,
     Hash.Hash,
-    Inspectable.Inspectable {
+    Inspectable.Inspectable,
+    Effect.Yieldable<Box<A>, Box<A>> {
   readonly [BoxTypeId]: BoxTypeId;
   readonly rows: number;
   readonly cols: number;

--- a/src/Cmd.ts
+++ b/src/Cmd.ts
@@ -130,7 +130,7 @@ export const cursorBackward: (columns?: number) => Box<AnsiStyle> =
  * ```typescript
  * import * as Cmd from "effect-boxes/Cmd"
  * import * as Box from "effect-boxes/Box"
- * import * as Ansi from "effect-boxes/Ansi"
+ * import * as Ansi from "effect-boxesi/Ansi"
  * import { pipe } from "effect"
  *
  * const statusAtPosition = pipe(

--- a/src/Renderer.ts
+++ b/src/Renderer.ts
@@ -327,6 +327,79 @@ export const render: {
 } = internal.render;
 
 // -----------------------------------------------------------------------------
+// Tracked Rendering
+// -----------------------------------------------------------------------------
+
+/**
+ * Result of a tracked render pass containing rendered output and reactive positions.
+ *
+ * Combines the rendered string output with position metadata for all reactive
+ * boxes in the layout. Positions use logical terminal cell coordinates.
+ *
+ * @example
+ * ```typescript
+ * import * as Renderer from "effect-boxes/Renderer"
+ * import * as Reactive from "effect-boxes/Reactive"
+ * import * as Box from "effect-boxes/Box"
+ * import { Effect, pipe, HashMap } from "effect"
+ *
+ * const layout = Box.vcat([
+ *   Reactive.makeReactive(Box.text("Header"), "header"),
+ *   Box.text("Body"),
+ *   Reactive.makeReactive(Box.text("Footer"), "footer")
+ * ], Box.left)
+ *
+ * const program = pipe(
+ *   Renderer.tracked(layout),
+ *   Effect.provide(Renderer.PlainRendererLive)
+ * )
+ * // Result: { lines: [...], output: "Header\nBody\nFooter", positions: HashMap }
+ * ```
+ *
+ * @category models
+ */
+export type RenderFrame = internal.RenderFrame;
+
+/**
+ * Renders a box to a string and collects reactive position metadata in one operation.
+ *
+ * Combines rendering with reactive position tracking, returning a `RenderFrame`
+ * containing the rendered lines, joined output string, and a position map for
+ * all reactive annotations. Supports both data-first and data-last calling patterns.
+ *
+ * @example
+ * ```typescript
+ * import * as Renderer from "effect-boxes/Renderer"
+ * import * as Reactive from "effect-boxes/Reactive"
+ * import * as Box from "effect-boxes/Box"
+ * import { Effect, pipe, HashMap } from "effect"
+ *
+ * const layout = Box.vcat([
+ *   Reactive.makeReactive(Box.text("Title"), "title"),
+ *   Reactive.makeReactive(Box.text("Button"), "btn")
+ * ], Box.left)
+ *
+ * const program = Effect.gen(function* () {
+ *   const frame = yield* Renderer.tracked(layout)
+ *   console.log(frame.output)
+ *   const btnPos = HashMap.get(frame.positions, "btn")
+ *   return frame
+ * }).pipe(Effect.provide(Renderer.AnsiRendererLive))
+ * ```
+ *
+ * @category rendering
+ */
+export const tracked: {
+  <A>(
+    config?: RenderConfig
+  ): (box: Box.Box<A>) => Effect.Effect<RenderFrame, never, Renderer>;
+  <A>(
+    box: Box.Box<A>,
+    config?: RenderConfig
+  ): Effect.Effect<RenderFrame, never, Renderer>;
+} = internal.tracked;
+
+// -----------------------------------------------------------------------------
 // Renderer Layers
 // -----------------------------------------------------------------------------
 

--- a/src/internal/box.ts
+++ b/src/internal/box.ts
@@ -11,6 +11,7 @@ import {
 } from "effect";
 import { dual } from "effect/Function";
 import { pipeArguments } from "effect/Pipeable";
+import { SingleShotGen } from "effect/Utils";
 import type * as Annotation from "../Annotation";
 import type * as Box from "../Box";
 import * as Renderer from "../Renderer";
@@ -125,6 +126,12 @@ const proto: Omit<Box.Box, "rows" | "content" | "cols" | "annotation"> = {
   },
   pipe() {
     return pipeArguments(this, arguments);
+  },
+  asEffect<A>(this: Box.Box<A>): Effect.Effect<Box.Box<A>> {
+    return Effect.succeed(this);
+  },
+  [Symbol.iterator]<A>(this: Box.Box<A>) {
+    return new SingleShotGen(this) as any;
   },
 };
 

--- a/src/internal/renderer.ts
+++ b/src/internal/renderer.ts
@@ -2,8 +2,10 @@ import { Array, Context, Effect, Option, pipe } from "effect";
 import { dual } from "effect/Function";
 import type * as Annotation from "../Annotation";
 import type * as Box from "../Box";
+import type * as Reactive from "../Reactive";
 import type * as R from "../Renderer";
 import { blanks, match, merge, takeP, takePA } from "./box";
+import { getPositions } from "./reactive";
 
 export class Renderer extends Context.Service<
   Renderer,
@@ -166,5 +168,34 @@ export const render = dual<
   Effect.gen(function* () {
     const lines = yield* renderBoxToLines(box);
     return renderLinesToString(lines, config);
+  })
+);
+
+// -----------------------------------------------------------------------------
+// Tracked Rendering
+// -----------------------------------------------------------------------------
+
+/** @internal */
+export interface RenderFrame {
+  readonly lines: ReadonlyArray<string>;
+  readonly output: string;
+  readonly positions: Reactive.PositionMap;
+}
+
+/** @internal */
+export const tracked = dual<
+  <A>(
+    config?: R.RenderConfig
+  ) => (box: Box.Box<A>) => Effect.Effect<RenderFrame, never, Renderer>,
+  <A>(
+    box: Box.Box<A>,
+    config?: R.RenderConfig
+  ) => Effect.Effect<RenderFrame, never, Renderer>
+>(2, (box, config) =>
+  Effect.gen(function* () {
+    const lines = yield* renderBoxToLines(box);
+    const output = renderLinesToString(lines, config);
+    const positions = getPositions(box);
+    return { lines, output, positions } as RenderFrame;
   })
 );

--- a/tests/box.test.ts
+++ b/tests/box.test.ts
@@ -1,5 +1,5 @@
 /** biome-ignore-all lint/suspicious/noExplicitAny: Testing runtime rather than build */
-import { String } from "effect";
+import { Effect, String } from "effect";
 import * as Equal from "effect/Equal";
 import * as Hash from "effect/Hash";
 import * as Inspectable from "effect/Inspectable";
@@ -1197,6 +1197,62 @@ describe("Annotation Functions", () => {
            |...`
         )
       );
+    });
+  });
+
+  describe("Yieldable", () => {
+    it("asEffect returns Effect.succeed(box)", () => {
+      const box = Box.text("hello");
+      const result = Effect.runSync(box.asEffect());
+      expect(Equal.equals(result, box)).toBe(true);
+    });
+
+    it("works with yield* inside Effect.gen", () => {
+      const box = Box.text("world");
+      const program = Effect.gen(function* () {
+        const yielded = yield* box;
+        return yielded;
+      });
+      const result = Effect.runSync(program);
+      expect(Equal.equals(result, box)).toBe(true);
+    });
+
+    it("works with pipe and yield*", () => {
+      const program = Effect.gen(function* () {
+        const layout = yield* Box.text("hello").pipe(
+          Box.moveRight(2),
+          Box.moveDown(1)
+        );
+        return layout;
+      });
+      const result = Effect.runSync(program);
+      expect(result.rows).toBe(2);
+      expect(result.cols).toBe(7);
+    });
+
+    it("preserves Equal and Hash after yielding", () => {
+      const box = Box.text("test");
+      const program = Effect.gen(function* () {
+        const yielded = yield* box;
+        return [
+          Equal.equals(yielded, box),
+          Hash.hash(yielded) === Hash.hash(box),
+        ] as const;
+      });
+      const [eq, hash] = Effect.runSync(program);
+      expect(eq).toBe(true);
+      expect(hash).toBe(true);
+    });
+
+    it("works with Effect.all", () => {
+      const program = Effect.all([
+        Box.text("a").asEffect(),
+        Box.text("b").asEffect(),
+      ]);
+      const results = Effect.runSync(program);
+      expect(results).toHaveLength(2);
+      expect(Box.renderPlainSync(results[0])).toBe("a");
+      expect(Box.renderPlainSync(results[1])).toBe("b");
     });
   });
 });

--- a/tests/reactive.test.ts
+++ b/tests/reactive.test.ts
@@ -1,7 +1,8 @@
-import { HashMap, Option } from "effect";
+import { Effect, HashMap, Option } from "effect";
 import { describe, expect, it } from "vitest";
 import * as Box from "../src/Box";
 import * as Reactive from "../src/Reactive";
+import * as Renderer from "../src/Renderer";
 
 describe("Reactive Annotations", () => {
   describe("ReactiveId", () => {
@@ -288,6 +289,86 @@ describe("Reactive Annotations", () => {
       expect(headerPos).toEqual({ row: 0, col: 0, rows: 1, cols: 6 });
       expect(okPos).toEqual({ row: 2, col: 0, rows: 1, cols: 4 });
       expect(cancelPos).toEqual({ row: 2, col: 5, rows: 1, cols: 8 }); // After [OK] + space
+    });
+  });
+
+  describe("renderTracked", () => {
+    it("returns lines, output, and positions", () => {
+      const layout = Box.vcat(
+        [
+          Reactive.makeReactive(Box.text("Header"), "header"),
+          Box.text("Body"),
+          Reactive.makeReactive(Box.text("Footer"), "footer"),
+        ],
+        Box.left
+      );
+
+      const frame = Effect.runSync(
+        Renderer.tracked(layout).pipe(
+          Effect.provide(Renderer.PlainRendererLive)
+        )
+      );
+
+      expect(frame.lines).toHaveLength(3);
+      expect(frame.output).toContain("Header");
+      expect(frame.output).toContain("Body");
+      expect(frame.output).toContain("Footer");
+
+      const headerPos = Option.getOrUndefined(
+        HashMap.get(frame.positions, "header")
+      );
+      const footerPos = Option.getOrUndefined(
+        HashMap.get(frame.positions, "footer")
+      );
+
+      expect(headerPos).toEqual({ row: 0, col: 0, rows: 1, cols: 6 });
+      expect(footerPos).toEqual({ row: 2, col: 0, rows: 1, cols: 6 });
+    });
+
+    it("works with data-last calling pattern", () => {
+      const layout = Reactive.makeReactive(Box.text("Test"), "test");
+
+      const frame = Effect.runSync(
+        layout.pipe(
+          Renderer.tracked(),
+          Effect.provide(Renderer.PlainRendererLive)
+        )
+      );
+
+      expect(frame.output).toContain("Test");
+      expect(Option.isSome(HashMap.get(frame.positions, "test"))).toBe(true);
+    });
+
+    it("returns empty positions for non-reactive boxes", () => {
+      const layout = Box.text("Plain");
+
+      const frame = Effect.runSync(
+        Renderer.tracked(layout).pipe(
+          Effect.provide(Renderer.PlainRendererLive)
+        )
+      );
+
+      expect(frame.output).toContain("Plain");
+      expect(HashMap.size(frame.positions)).toBe(0);
+    });
+
+    it("works with yield* inside Effect.gen", () => {
+      const layout = Box.vcat(
+        [
+          Reactive.makeReactive(Box.text("A"), "a"),
+          Reactive.makeReactive(Box.text("B"), "b"),
+        ],
+        Box.left
+      );
+
+      const program = Effect.gen(function* () {
+        const frame = yield* Renderer.tracked(layout);
+        return frame;
+      }).pipe(Effect.provide(Renderer.PlainRendererLive));
+
+      const frame = Effect.runSync(program);
+      expect(frame.output).toContain("A");
+      expect(HashMap.size(frame.positions)).toBe(2);
     });
   });
 });


### PR DESCRIPTION
# Changes

- Added local source reference setup guide documentation
- Added `Effect.Yieldable` support to Box
- Added `renderTracked` for reactive position tracking