### PR TITLE
refactor: use bracket notation for property access

### DIFF
--- a/.changeset/nice-clocks-push.md
+++ b/.changeset/nice-clocks-push.md
@@ -1,0 +1,5 @@
+---
+"effect-boxes": patch
+---
+
+use bracket notation and RegExp constructor

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,8 +37,9 @@ jobs:
           bun-version: latest
       - uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
+      - run: npm --version
       - run: bun install --frozen-lockfile
       - name: Create Release PR or Publish
         id: changesets

--- a/src/internal/reactive.ts
+++ b/src/internal/reactive.ts
@@ -20,8 +20,8 @@ export const isReactive = (value: unknown): value is Reactive.Reactive =>
   value !== null &&
   "_tag" in value &&
   "id" in value &&
-  (value as Record<PropertyKey, unknown>)._tag === "ReactiveId" &&
-  typeof (value as Record<PropertyKey, unknown>).id === "string";
+  (value as Record<PropertyKey, unknown>)["_tag"] === "ReactiveId" &&
+  typeof (value as Record<PropertyKey, unknown>)["id"] === "string";
 
 /** @internal */
 export const make = (id: string): Reactive.Reactive => ({

--- a/src/internal/width.ts
+++ b/src/internal/width.ts
@@ -44,11 +44,15 @@ export const segments = (str: string): readonly string[] => {
   return result;
 };
 
-const zeroWidthClusterRegex =
-  /^(?:\p{Default_Ignorable_Code_Point}|\p{Control}|\p{Mark}|\p{Surrogate})+$/v; // zero-width clusters (control chars, marks, surrogates, etc.)
-const leadingNonPrintingRegex =
-  /^[\p{Default_Ignorable_Code_Point}\p{Control}\p{Format}\p{Mark}\p{Surrogate}]+/v; // leading non-printing characters in a cluster
-const rgiEmojiRegex = /^\p{RGI_Emoji}$/v; // RGI (Recommended for General Interchange) emoji sequences
+const zeroWidthClusterRegex = new RegExp(
+  "^(?:\\p{Default_Ignorable_Code_Point}|\\p{Control}|\\p{Mark}|\\p{Surrogate})+$",
+  "v"
+); // zero-width clusters (control chars, marks, surrogates, etc.)
+const leadingNonPrintingRegex = new RegExp(
+  "^[\\p{Default_Ignorable_Code_Point}\\p{Control}\\p{Format}\\p{Mark}\\p{Surrogate}]+",
+  "v"
+); // leading non-printing characters in a cluster
+const rgiEmojiRegex = new RegExp("^\\p{RGI_Emoji}$", "v"); // RGI (Recommended for General Interchange) emoji sequences
 
 const WIDE_CHAR_RANGES = [
   // Hangul Jamo


### PR DESCRIPTION
# Changes

- Refactored to use bracket notation for property access
- Updated to use RegExp constructor instead of literal syntax
- Upgraded Node.js to v24 in CI pipeline
- Added Node.js version check to CI workflow