### PR TITLE
refactor: move effect to peer and dev dependencies

### DIFF
--- a/.changeset/warm-canyons-drive.md
+++ b/.changeset/warm-canyons-drive.md
@@ -1,0 +1,5 @@
+---
+"effect-boxes": patch
+---
+
+make effect a peer dependency of effect-boxes

--- a/bun.lock
+++ b/bun.lock
@@ -4,9 +4,6 @@
   "workspaces": {
     "": {
       "name": "effect-boxes",
-      "dependencies": {
-        "effect": "4.0.0-beta.59",
-      },
       "devDependencies": {
         "@biomejs/biome": "2.4.13",
         "@changesets/changelog-github": "^0.6.0",
@@ -17,9 +14,13 @@
         "@microsoft/tsdoc-config": "^0.18.1",
         "@types/bun": "^1.3.13",
         "@vitest/coverage-v8": "4.1.5",
+        "effect": "4.0.0-beta.59",
         "tinybench": "^6.0.1",
         "typescript": "^6.0.3",
         "vitest": "^4.1.5",
+      },
+      "peerDependencies": {
+        "effect": ">=4.0.0-beta.59",
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -79,10 +79,11 @@
     "postinstall": "effect-language-service patch",
     "prepack": "bun run type-check"
   },
-  "dependencies": {
-    "effect": "4.0.0-beta.59"
+  "peerDependencies": {
+    "effect": ">=4.0.0-beta.59"
   },
   "devDependencies": {
+    "effect": "4.0.0-beta.59",
     "@biomejs/biome": "2.4.13",
     "@changesets/changelog-github": "^0.6.0",
     "@changesets/cli": "^2.31.0",


### PR DESCRIPTION
# Changes

- Moved `effect` package from dependencies to peer dependencies
- Added `effect` to dev dependencies for development and testing purposes