### PR TITLE
refactor: improve consistency across API variable naming

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -418,6 +418,45 @@ const result = pipe(
 );
 ```
 
+### API Consistency Standards
+
+These rules ensure a predictable, learnable public API (see Issue #14):
+
+1. **Primary parameter naming**: Always use `self` for the primary data
+   parameter in all public functions. Never use `b`, `box`, or other names.
+
+2. **Secondary parameter naming**: Use descriptive names for other parameters,
+   not single-letter abbreviations. For binary box operations, use `that` for
+   the second operand (not `l`, `t`, etc.).
+
+3. **Return type annotations**: All public functions must have explicit return
+   type annotations. Never rely on inference for exports.
+
+4. **Generic naming conventions**:
+   - `A` for the primary type parameter (the annotation type on `self`)
+   - `B` for a secondary type parameter (e.g., the other box's annotation)
+   - In data-first dual overloads, `self`'s type parameter should be `A`
+
+5. **Parameter ordering in dual functions**:
+   - Data-first: `(self: Box<A>, ...options)`
+   - Data-last: `(...options) => (self: Box<A>) => Box<A>`
+
+6. **Dual function template**:
+
+```typescript
+// ✅ Correct dual function pattern
+export const functionName = dual<
+  (param: Type) => <A>(self: Box<A>) => Box<A>,
+  <A>(self: Box<A>, param: Type) => Box<A>
+>(arity, (self, param) => /* implementation */)
+
+// ✅ Binary box operation
+export const append = dual<
+  <B>(that: Box<B>) => <A>(self: Box<A>) => Box<A | B>,
+  <A, B>(self: Box<A>, that: Box<B>) => Box<A | B>
+>(2, (self, that) => /* implementation */)
+```
+
 ## 🚨 Error Handling
 
 ### Pure Functions with Option/Either

--- a/src/Box.ts
+++ b/src/Box.ts
@@ -328,8 +328,8 @@ export const para: {
  * @category combinators
  */
 export const combine: {
-  <B>(l: Box<B>): <A>(self: Box<A>) => Box<A | B>;
-  <A, B>(self: Box<A>, l: Box<B>): Box<A | B>;
+  <B>(that: Box<B>): <A>(self: Box<A>) => Box<A | B>;
+  <A, B>(self: Box<A>, that: Box<B>): Box<A | B>;
 } = internal.combine;
 
 /**
@@ -403,7 +403,7 @@ export const combineAll: <T extends readonly Box<unknown>[]>(
  * @note Haskell: `rows :: Box -> Int`
  * @category utilities
  */
-export const rows: <A>(b: Box<A>) => number = internal.rows;
+export const rows: <A>(self: Box<A>) => number = internal.rows;
 
 /**
  * Gets the number of columns in a box.
@@ -431,7 +431,7 @@ export const rows: <A>(b: Box<A>) => number = internal.rows;
  * @note Haskell: `cols :: Box -> Int`
  * @category utilities
  */
-export const cols: <A>(b: Box<A>) => number = internal.cols;
+export const cols: <A>(self: Box<A>) => number = internal.cols;
 
 // -----------------------------------------------------------------------------
 // Utilities
@@ -442,7 +442,7 @@ export const cols: <A>(b: Box<A>) => number = internal.cols;
  *
  * @category constructors
  */
-export const make: <A>(b: {
+export const make: <A>(self: {
   rows: number;
   cols: number;
   content: Content<A>;
@@ -578,8 +578,8 @@ export const vcat: {
  * @category combinators
  */
 export const hAppend: {
-  <A>(l: Box<A>): (self: Box<A>) => Box<A>;
-  <A>(self: Box<A>, l: Box<A>): Box<A>;
+  <A>(that: Box<A>): (self: Box<A>) => Box<A>;
+  <A>(self: Box<A>, that: Box<A>): Box<A>;
 } = internal.hAppend;
 
 /**
@@ -609,8 +609,8 @@ export const hAppend: {
  * @category combinators
  */
 export const hcatWithSpace: {
-  <A>(l: Box<A>): (self: Box<A>) => Box<A>;
-  <A>(self: Box<A>, l: Box<A>): Box<A>;
+  <A>(that: Box<A>): (self: Box<A>) => Box<A>;
+  <A>(self: Box<A>, that: Box<A>): Box<A>;
 } = internal.hcatWithSpace;
 
 /**
@@ -635,8 +635,8 @@ export const hcatWithSpace: {
  * @category combinators
  */
 export const vAppend: {
-  <A>(t: Box<A>): (self: Box<A>) => Box<A>;
-  <A>(self: Box<A>, t: Box<A>): Box<A>;
+  <A>(that: Box<A>): (self: Box<A>) => Box<A>;
+  <A>(self: Box<A>, that: Box<A>): Box<A>;
 } = internal.vAppend;
 
 /**
@@ -668,8 +668,8 @@ export const vAppend: {
  * @category combinators
  */
 export const vcatWithSpace: {
-  <A>(t: Box<A>): (self: Box<A>) => Box<A>;
-  <A>(self: Box<A>, t: Box<A>): Box<A>;
+  <A>(that: Box<A>): (self: Box<A>) => Box<A>;
+  <A>(self: Box<A>, that: Box<A>): Box<A>;
 } = internal.vcatWithSpace;
 
 /**
@@ -1225,9 +1225,9 @@ export const renderPlainSync: <A>(self: Box<A>) => string =
 export const render: {
   <A>(
     config?: Renderer.RenderConfig | undefined
-  ): (box: Box<A>) => Effect.Effect<string, never, Renderer.Renderer>;
+  ): (self: Box<A>) => Effect.Effect<string, never, Renderer.Renderer>;
   <A>(
-    box: Box<A>,
+    self: Box<A>,
     config?: Renderer.RenderConfig
   ): Effect.Effect<string, never, Renderer.Renderer>;
 } = internalRender.render;
@@ -1251,7 +1251,7 @@ export const render: {
  * @category utilities
  */
 export const printBox: <A>(
-  b: Box<A>
+  self: Box<A>
 ) => Effect.Effect<void, never, Renderer.Renderer> = internalRender.printBox;
 
 /*
@@ -1282,8 +1282,8 @@ export const printBox: <A>(
  * @category transformations
  */
 export const annotate: {
-  <A>(annotation: Annotation<A>): <B>(self: Box<B>) => Box<A>;
-  <B, A>(self: Box<B>, annotation: Annotation<A>): Box<A>;
+  <B>(annotation: Annotation<B>): <A>(self: Box<A>) => Box<B>;
+  <A, B>(self: Box<A>, annotation: Annotation<B>): Box<B>;
 } = internal.annotate;
 
 /**

--- a/src/internal/box-render.ts
+++ b/src/internal/box-render.ts
@@ -28,9 +28,9 @@ export const renderPlainSync = <A>(self: Box.Box<A>): string =>
 
 /** @internal */
 export const printBox = (
-  box: Box.Box<unknown>
+  self: Box.Box<unknown>
 ): Effect.Effect<void, never, Renderer.Renderer> =>
   Effect.gen(function* () {
-    const rendered = yield* render(box);
+    const rendered = yield* render(self);
     yield* Console.log(rendered);
   });

--- a/src/internal/box.ts
+++ b/src/internal/box.ts
@@ -129,7 +129,7 @@ const proto: Omit<Box.Box, "rows" | "content" | "cols" | "annotation"> = {
     return Effect.succeed(this);
   },
   [Symbol.iterator]<A>(this: Box.Box<A>) {
-    return new SingleShotGen(this) as any;
+    return new SingleShotGen(this);
   },
 };
 
@@ -176,18 +176,18 @@ export const center2: Box.Alignment = "AlignCenter2";
 
 /** @internal */
 
-export const make = <A>(b: {
+export const make = <A>(self: {
   rows: number;
   cols: number;
   content: Box.Content<A>;
   annotation?: import("../Annotation").Annotation<A> | undefined;
 }): Box.Box<A> => {
   const box = Object.create(proto);
-  box.rows = Math.max(0, b.rows);
-  box.cols = Math.max(0, b.cols);
-  box.content = b.content;
-  if (b.annotation) {
-    box.annotation = b.annotation;
+  box.rows = Math.max(0, self.rows);
+  box.cols = Math.max(0, self.cols);
+  box.content = self.content;
+  if (self.annotation) {
+    box.annotation = self.annotation;
   }
 
   return box;
@@ -249,12 +249,12 @@ export const para = dual<
 /** @internal */
 
 export const combine = dual<
-  <B>(l: Box.Box<B>) => <A>(self: Box.Box<A>) => Box.Box<A | B>,
-  <A, B>(self: Box.Box<A>, l: Box.Box<B>) => Box.Box<A | B>
+  <B>(that: Box.Box<B>) => <A>(self: Box.Box<A>) => Box.Box<A | B>,
+  <A, B>(self: Box.Box<A>, that: Box.Box<B>) => Box.Box<A | B>
 >(
   2,
-  <A, B>(self: Box.Box<A>, l: Box.Box<B>): Box.Box<A | B> =>
-    hcat([self, l], top)
+  <A, B>(self: Box.Box<A>, that: Box.Box<B>): Box.Box<A | B> =>
+    hcat([self, that], top)
 );
 
 /** @internal */
@@ -276,10 +276,10 @@ export const combineAll = <T extends readonly Box.Box<unknown>[]>(
 };
 
 /** @internal */
-export const rows = <A>(b: Box.Box<A>): number => b.rows;
+export const rows = <A>(self: Box.Box<A>): number => self.rows;
 
 /** @internal */
-export const cols = <A>(b: Box.Box<A>): number => b.cols;
+export const cols = <A>(self: Box.Box<A>): number => self.cols;
 
 const sumMax = <A>(
   f: (a: A) => number,
@@ -354,34 +354,41 @@ export const vcat = dual<
 
 /** @internal */
 export const hAppend = dual<
-  <A>(l: Box.Box<A>) => (self: Box.Box<A>) => Box.Box<A>,
-  <A>(self: Box.Box<A>, l: Box.Box<A>) => Box.Box<A>
->(2, <A>(self: Box.Box<A>, l: Box.Box<A>): Box.Box<A> => hcat([self, l], top));
+  <A>(that: Box.Box<A>) => (self: Box.Box<A>) => Box.Box<A>,
+  <A>(self: Box.Box<A>, that: Box.Box<A>) => Box.Box<A>
+>(
+  2,
+  <A>(self: Box.Box<A>, that: Box.Box<A>): Box.Box<A> => hcat([self, that], top)
+);
 
 /** @internal */
 export const hcatWithSpace = dual<
-  <A>(l: Box.Box<A>) => (self: Box.Box<A>) => Box.Box<A>,
-  <A>(self: Box.Box<A>, l: Box.Box<A>) => Box.Box<A>
+  <A>(that: Box.Box<A>) => (self: Box.Box<A>) => Box.Box<A>,
+  <A>(self: Box.Box<A>, that: Box.Box<A>) => Box.Box<A>
 >(
   2,
-  <A>(self: Box.Box<A>, l: Box.Box<A>): Box.Box<A> =>
-    hcat([self, emptyBox(0, 1), l], top)
+  <A>(self: Box.Box<A>, that: Box.Box<A>): Box.Box<A> =>
+    hcat([self, emptyBox(0, 1), that], top)
 );
 
 /** @internal */
 export const vAppend = dual<
-  <A>(t: Box.Box<A>) => (self: Box.Box<A>) => Box.Box<A>,
-  <A>(self: Box.Box<A>, t: Box.Box<A>) => Box.Box<A>
->(2, <A>(self: Box.Box<A>, t: Box.Box<A>): Box.Box<A> => vcat([self, t], left));
+  <A>(that: Box.Box<A>) => (self: Box.Box<A>) => Box.Box<A>,
+  <A>(self: Box.Box<A>, that: Box.Box<A>) => Box.Box<A>
+>(
+  2,
+  <A>(self: Box.Box<A>, that: Box.Box<A>): Box.Box<A> =>
+    vcat([self, that], left)
+);
 
 /** @internal */
 export const vcatWithSpace = dual<
-  <A>(t: Box.Box<A>) => (self: Box.Box<A>) => Box.Box<A>,
-  <A>(self: Box.Box<A>, t: Box.Box<A>) => Box.Box<A>
+  <A>(that: Box.Box<A>) => (self: Box.Box<A>) => Box.Box<A>,
+  <A>(self: Box.Box<A>, that: Box.Box<A>) => Box.Box<A>
 >(
   2,
-  <A>(self: Box.Box<A>, t: Box.Box<A>): Box.Box<A> =>
-    vcat([self, emptyBox(1, 0), t], left)
+  <A>(self: Box.Box<A>, that: Box.Box<A>): Box.Box<A> =>
+    vcat([self, emptyBox(1, 0), that], left)
 );
 
 /** @internal */

--- a/src/internal/renderer.ts
+++ b/src/internal/renderer.ts
@@ -159,14 +159,14 @@ export const renderLinesToString = dual<
 export const render = dual<
   <A>(
     config?: R.RenderConfig
-  ) => (box: Box.Box<A>) => Effect.Effect<string, never, Renderer>,
+  ) => (self: Box.Box<A>) => Effect.Effect<string, never, Renderer>,
   <A>(
-    box: Box.Box<A>,
+    self: Box.Box<A>,
     config?: R.RenderConfig
   ) => Effect.Effect<string, never, Renderer>
->(2, (box, config) =>
+>(2, (self, config) =>
   Effect.gen(function* () {
-    const lines = yield* renderBoxToLines(box);
+    const lines = yield* renderBoxToLines(self);
     return renderLinesToString(lines, config);
   })
 );
@@ -186,18 +186,18 @@ export interface RenderFrame {
 export const tracked = dual<
   <A>(
     config?: R.RenderConfig
-  ) => (box: Box.Box<A>) => Effect.Effect<RenderFrame, never, Renderer>,
+  ) => (self: Box.Box<A>) => Effect.Effect<RenderFrame, never, Renderer>,
   <A>(
-    box: Box.Box<A>,
+    self: Box.Box<A>,
     config?: R.RenderConfig
   ) => Effect.Effect<RenderFrame, never, Renderer>
 >(
   (args) => isBox(args[0]),
-  (box, config) =>
+  (self, config) =>
     Effect.gen(function* () {
-      const lines = yield* renderBoxToLines(box);
+      const lines = yield* renderBoxToLines(self);
       const output = renderLinesToString(lines, config);
-      const positions = getPositions(box);
+      const positions = getPositions(self);
       return { lines, output, positions } as RenderFrame;
     })
 );


### PR DESCRIPTION
## Goal/Scope

new consistency conventions:

1. **Primary parameter**: always self
The first/primary data parameter in every public function must be named self. Previously some functions used b, box, or other names.
2. **Secondary operand**: always that
Binary box operations (where two boxes are combined) must name the second operand that. Previously some used l (misleadingly suggesting "left" for what was actually the right-side box) or t.
3. **Generic ordering**: A on self, B on secondary
In dual function overloads, self's type parameter should always be A. A secondary box or annotation type should be B.
4. **Explicit return types on all exports**
_Already satisfied_ -- documented as a rule to maintain going forward.

---
- [x] closes #14