### PR TITLE
feat: optionally disable border sides

### DIFF
--- a/.changeset/vast-candles-tickle.md
+++ b/.changeset/vast-candles-tickle.md
@@ -1,0 +1,30 @@
+---
+"effect-boxes": minor
+---
+
+add selective border sides via `sides` option on `Box.border()` closes #42
+
+Control which sides of the border are drawn by passing a `sides` object with `top`, `right`, `bottom`, and `left` booleans (all default to `true`).
+
+```typescript
+import { pipe } from "effect";
+import * as Box from "effect-boxes/Box";
+
+const tab = pipe(
+  Box.text("Tab"),
+  Box.pad(0, 1),
+  Box.border("rounded", { sides: { bottom: false } })
+);
+console.log(Box.renderPlainSync(tab));
+// ╭─────╮
+// │ Tab │
+
+const ruled = pipe(
+  Box.text("Section"),
+  Box.border("single", { sides: { left: false, right: false } })
+);
+console.log(Box.renderPlainSync(ruled));
+// ───────
+// Section
+// ───────
+```

--- a/docs/using-box.md
+++ b/docs/using-box.md
@@ -189,6 +189,92 @@ const positioned = pipe(Box.text("Hello"), Box.moveRight(5), Box.moveDown(2));
 // Result: 2 empty rows, then "     Hello"
 ```
 
+## Borders and Padding
+
+### Borders
+
+Add a border around a box using Unicode box-drawing characters. The default
+style is `"single"`.
+
+```typescript
+import { pipe } from "effect";
+import * as Box from "effect-boxes/Box";
+
+// Default single border
+const bordered = pipe(Box.text("Hello"), Box.border());
+// ┌─────┐
+// │Hello│
+// └─────┘
+
+// Double border
+const doubleBordered = pipe(Box.text("Hello"), Box.border("double"));
+// ╔═════╗
+// ║Hello║
+// ╚═════╝
+
+// Rounded border
+const rounded = pipe(Box.text("Hello"), Box.border("rounded"));
+// ╭─────╮
+// │Hello│
+// ╰─────╯
+```
+
+Available border styles: `"single"`, `"double"`, `"rounded"`, `"thick"`,
+`"ascii"`.
+
+#### Colored Borders
+
+Use the `annotation` option to color the border characters:
+
+```typescript
+import { pipe } from "effect";
+import * as Box from "effect-boxes/Box";
+import * as Ansi from "effect-boxes/Ansi";
+
+const warning = pipe(
+  Box.text("Warning!"),
+  Box.border("rounded", { annotation: Ansi.yellow })
+);
+console.log(Box.renderPrettySync(warning));
+```
+
+### Padding
+
+Add empty space around a box's content. Supports CSS-like shorthand for
+specifying padding per side.
+
+```typescript
+import { pipe } from "effect";
+import * as Box from "effect-boxes/Box";
+
+// Uniform padding of 1 on all sides
+const padded1 = pipe(Box.text("Hi"), Box.pad(1));
+
+// Vertical and horizontal padding (1 row top/bottom, 2 cols left/right)
+const padded2 = pipe(Box.text("Hi"), Box.pad(1, 2));
+
+// Per-side padding: top, right, bottom, left (CSS order)
+const padded3 = pipe(Box.text("Hi"), Box.pad(0, 2, 1, 2));
+```
+
+### Combining Padding and Borders
+
+Padding and borders compose naturally with `pipe`:
+
+```typescript
+import { pipe } from "effect";
+import * as Box from "effect-boxes/Box";
+
+const panel = pipe(Box.text("Hi"), Box.pad(1, 2), Box.border("rounded"));
+console.log(Box.renderPlainSync(panel));
+// ╭──────╮
+// │      │
+// │  Hi  │
+// │      │
+// ╰──────╯
+```
+
+
 ## Rendering
 
 ```typescript

--- a/scratchpad/03-static-demo.ts
+++ b/scratchpad/03-static-demo.ts
@@ -225,6 +225,81 @@ const positionDemo = (() => {
 })();
 
 // ---------------------------------------------------------------------------
+// 7. Per-Side Border Toggles
+// ---------------------------------------------------------------------------
+
+const borderSidesDemo = (() => {
+  // Tabbed interface (Lip Gloss style): all tabs skip the bottom border,
+  // a connector line joins them to the content panel using junction chars.
+  const labels = ["Overview", "Details", "Settings"];
+  const activeIndex = 2;
+
+  const tabBoxes = labels.map((label, i) =>
+    Box.text(label).pipe(
+      Box.pad(0, 1),
+      Box.border("rounded", {
+        sides: { bottom: false },
+        annotation: i === activeIndex ? Ansi.cyan : Ansi.dim,
+      }),
+      i === activeIndex
+        ? Box.annotate(Ansi.combine(Ansi.bold, Ansi.cyan))
+        : (x) => x
+    )
+  );
+
+  const tabs = Box.hcat(tabBoxes, Box.top);
+
+  // Active tab gets a gap (spaces), inactive tabs get ─ with ┴ at junctions
+  let connector = "";
+  for (let i = 0; i < labels.length; i++) {
+    const innerWidth = tabBoxes[i]!.cols - 2;
+    const isActive = i === activeIndex;
+
+    // Left edge or junction
+    if (i === 0) {
+      connector += isActive ? "│" : "├";
+    } else {
+      // Two chars for the junction (replacing ││ from adjacent tab borders)
+      const prevActive = i - 1 === activeIndex;
+      if (prevActive) {
+        // active → inactive: close active's corner, tee for inactive
+        connector += "╰┴";
+      } else if (isActive) {
+        // inactive → active: tee for inactive, close corner into active
+        connector += "┴╯";
+      } else {
+        // both inactive
+        connector += "┴┴";
+      }
+    }
+
+    connector += isActive ? " ".repeat(innerWidth) : "─".repeat(innerWidth);
+  }
+  // Right edge
+  connector += activeIndex === labels.length - 1 ? "│" : "┤";
+
+  const connectorLine = Box.text(connector).pipe(Box.annotate(Ansi.cyan));
+
+  // Content panel: width matches tabs
+  const tabContent = Box.para(
+    "This panel joins seamlessly with the active tab above " +
+      "because the tab's bottom border is disabled.",
+    Box.left,
+    tabs.cols - 4 // -2 border -2 padding
+  ).pipe(
+    Box.pad(0, 1),
+    Box.border("rounded", {
+      sides: { top: false },
+      annotation: Ansi.cyan,
+    })
+  );
+
+  const tabSection = Box.vcat([tabs, connectorLine, tabContent], Box.left);
+
+  return Box.vcat([sectionLabel("Border Layouts"), tabSection], Box.left);
+})();
+
+// ---------------------------------------------------------------------------
 // Assemble
 // ---------------------------------------------------------------------------
 
@@ -237,6 +312,7 @@ const demo = Box.vsep(
     alignmentDemo,
     barChartDemo,
     positionDemo,
+    borderSidesDemo,
   ],
   1,
   Box.left

--- a/src/internal/box.ts
+++ b/src/internal/box.ts
@@ -1054,6 +1054,12 @@ const borderStyleToChars = (style: BorderStyle): BorderChars => {
 /** @internal */
 export interface BorderOptions<A> {
   readonly annotation?: Annotation.Annotation<A>;
+  readonly sides?: {
+    readonly top?: boolean; // default: true
+    readonly right?: boolean; // default: true
+    readonly bottom?: boolean; // default: true
+    readonly left?: boolean; // default: true
+  };
 }
 
 /** @internal */
@@ -1082,30 +1088,50 @@ export const border = dual<
     const borderText = (s: string): Box.Box<A> =>
       options?.annotation ? annotate(text(s), options.annotation) : text(s);
 
+    const when = (cond: boolean, box: Box.Box<A>): Box.Box<A> =>
+      cond ? box : nullBox;
+
     const sideCol = vcat(
       Array.makeBy(self.rows, () => borderChar(chars.vertical)),
       left
     );
 
+    const {
+      top: wTop = true,
+      right: wRight = true,
+      bottom: wBottom = true,
+      left: wLeft = true,
+    } = options?.sides ?? {};
+
+    const topBorder = when(
+      wTop,
+      hcat(
+        [
+          when(wLeft, borderChar(chars.topLeft)),
+          borderText(chars.horizontal.repeat(self.cols)),
+          when(wRight, borderChar(chars.topRight)),
+        ],
+        top
+      )
+    );
+
+    const bottomBorder = when(
+      wBottom,
+      hcat(
+        [
+          when(wLeft, borderChar(chars.bottomLeft)),
+          borderText(chars.horizontal.repeat(self.cols)),
+          when(wRight, borderChar(chars.bottomRight)),
+        ],
+        top
+      )
+    );
+
     return vcat(
       [
-        hcat(
-          [
-            borderChar(chars.topLeft),
-            borderText(chars.horizontal.repeat(self.cols)),
-            borderChar(chars.topRight),
-          ],
-          top
-        ),
-        hcat([sideCol, self, sideCol], top),
-        hcat(
-          [
-            borderChar(chars.bottomLeft),
-            borderText(chars.horizontal.repeat(self.cols)),
-            borderChar(chars.bottomRight),
-          ],
-          top
-        ),
+        topBorder,
+        hcat([when(wLeft, sideCol), self, when(wRight, sideCol)], top),
+        bottomBorder,
       ],
       left
     );

--- a/tests/border.test.ts
+++ b/tests/border.test.ts
@@ -102,4 +102,157 @@ describe("Box.border", () => {
     const result = pipe(Box.emptyBox(0, 0), Box.border());
     expect(result.cols).toBe(2);
   });
+
+  describe("per-side border toggles", () => {
+    it("no bottom border", () => {
+      const result = pipe(
+        Box.text("Hi"),
+        Box.border("single", { sides: { bottom: false } })
+      );
+      expect(Box.renderPlainSync(result)).toBe(
+        String.stripMargin(
+          `|┌──┐
+           |│Hi│`
+        )
+      );
+    });
+
+    it("no top border", () => {
+      const result = pipe(
+        Box.text("Hi"),
+        Box.border("single", { sides: { top: false } })
+      );
+      expect(Box.renderPlainSync(result)).toBe(
+        String.stripMargin(
+          `|│Hi│
+           |└──┘`
+        )
+      );
+    });
+
+    it("no left border", () => {
+      const result = pipe(
+        Box.text("Hi"),
+        Box.border("single", { sides: { left: false } })
+      );
+      expect(Box.renderPlainSync(result)).toBe(
+        String.stripMargin(
+          `|──┐
+           |Hi│
+           |──┘`
+        )
+      );
+    });
+
+    it("no right border", () => {
+      const result = pipe(
+        Box.text("Hi"),
+        Box.border("single", { sides: { right: false } })
+      );
+      expect(Box.renderPlainSync(result)).toBe(
+        String.stripMargin(
+          `|┌──
+           |│Hi
+           |└──`
+        )
+      );
+    });
+
+    it("left border only (quote style)", () => {
+      const result = pipe(
+        Box.text("Quote"),
+        Box.border("thick", {
+          sides: { top: false, right: false, bottom: false },
+        })
+      );
+      expect(Box.renderPlainSync(result)).toBe(
+        String.stripMargin(
+          `|┃Quote`
+        )
+      );
+    });
+
+    it("top and bottom only (horizontal rule style)", () => {
+      const result = pipe(
+        Box.text("Hi"),
+        Box.border("single", { sides: { left: false, right: false } })
+      );
+      expect(Box.renderPlainSync(result)).toBe(
+        String.stripMargin(
+          `|──
+           |Hi
+           |──`
+        )
+      );
+    });
+
+    it("no borders at all returns content unchanged", () => {
+      const content = Box.text("Hi");
+      const result = pipe(
+        content,
+        Box.border("single", {
+          sides: { top: false, right: false, bottom: false, left: false },
+        })
+      );
+      expect(Box.renderPlainSync(result)).toBe(Box.renderPlainSync(content));
+    });
+
+    it("dimensions adjust when sides are disabled", () => {
+      const content = Box.text("Hi");
+
+      const noBottom = pipe(
+        content,
+        Box.border("single", { sides: { bottom: false } })
+      );
+      expect(noBottom.rows).toBe(content.rows + 1);
+      expect(noBottom.cols).toBe(content.cols + 2);
+
+      const noLeftRight = pipe(
+        content,
+        Box.border("single", { sides: { left: false, right: false } })
+      );
+      expect(noLeftRight.rows).toBe(content.rows + 2);
+      expect(noLeftRight.cols).toBe(content.cols);
+    });
+
+    it("works with rounded style and sides", () => {
+      const result = pipe(
+        Box.text("Tab"),
+        Box.border("rounded", { sides: { bottom: false } })
+      );
+      expect(Box.renderPlainSync(result)).toBe(
+        String.stripMargin(
+          `|╭───╮
+           |│Tab│`
+        )
+      );
+    });
+
+    it("corners omitted when adjacent sides disabled", () => {
+      const result = pipe(
+        Box.text("X"),
+        Box.border("single", { sides: { top: false, left: false } })
+      );
+      expect(Box.renderPlainSync(result)).toBe(
+        String.stripMargin(
+          `|X│
+           |─┘`
+        )
+      );
+    });
+
+    it("works with multi-line content and partial borders", () => {
+      const result = pipe(
+        Box.text("AB\nCD"),
+        Box.border("single", { sides: { right: false, bottom: false } })
+      );
+      expect(Box.renderPlainSync(result)).toBe(
+        String.stripMargin(
+          `|┌──
+           |│AB
+           |│CD`
+        )
+      );
+    });
+  });
 });

--- a/tests/border.test.ts
+++ b/tests/border.test.ts
@@ -165,11 +165,7 @@ describe("Box.border", () => {
           sides: { top: false, right: false, bottom: false },
         })
       );
-      expect(Box.renderPlainSync(result)).toBe(
-        String.stripMargin(
-          `|┃Quote`
-        )
-      );
+      expect(Box.renderPlainSync(result)).toBe(String.stripMargin(`|┃Quote`));
     });
 
     it("top and bottom only (horizontal rule style)", () => {


### PR DESCRIPTION
## Goal/Scope

Adding the ability to disable border sides to allow for combining and composition of layouts.

This enables some pretty wild TUI layouts

```
Border Layouts 
╭──────────╮╭─────────╮╭──────────╮
│ Overview ││ Details ││ Settings │
├──────────┴┴─────────┴╯          │
│ This panel joins seamlessly     │
│ with the active tab above       │
│ because the tab's bottom border │
│ is disabled.                    │
╰─────────────────────────────────╯
```

---
- [x] closes #42