### PR TITLE
feat: add contrained box helpers

### DIFF
--- a/.changeset/green-ways-wash.md
+++ b/.changeset/green-ways-wash.md
@@ -1,0 +1,34 @@
+---
+"effect-boxes": minor
+---
+
+add width and height constraint combinators for responsive terminal layouts, closes #44
+
+Four new functions enforce minimum and maximum dimensions on a box:
+
+- Box.minWidth(n) -- pads with spaces to ensure at least n columns
+- Box.maxWidth(n) -- hard-truncates lines exceeding n columns
+- Box.minHeight(n) -- pads with blank rows to ensure at least n rows
+- Box.maxHeight(n) -- keeps only the first n rows
+
+All support both data-first and data-last (pipe) usage via dual.
+
+```typescript
+import { pipe } from "effect";
+import * as Box from "effect-boxes/Box";
+
+// Clamp a box to fit a 40x10 panel
+const panel = pipe(
+  Box.text("Hello World"),
+  Box.minWidth(40),
+  Box.maxHeight(10)
+);
+// Combine with truncate for ellipsis on overflow
+const capped = pipe(
+  Box.text("A".repeat(80)),
+  Box.truncate(40, Box.left),
+  Box.minWidth(60)
+);
+```
+
+Internally, maxWidth and Box.truncate now share a truncateWidth helper that handles the recursive box tree-walk, reducing code duplication.

--- a/scratchpad/00-index.ts
+++ b/scratchpad/00-index.ts
@@ -10,6 +10,7 @@ import { main as compositionDemo } from "./05-composition-demo";
 import { main as htmlDemo } from "./06-html-rendering";
 import { main as textPromptDemo } from "./07-text-prompt";
 import { main as perlinDemo } from "./08-perlin-flow-field";
+import { main as logViewerDemo } from "./09-log-viewer";
 
 const demos = [
   {
@@ -53,6 +54,12 @@ const demos = [
     value: "perlin",
     description: "Animated noise-driven walkers with cursor positioning",
   },
+  {
+    title: "9. Log Viewer",
+    value: "log-viewer",
+    description:
+      "Scrollable stream log viewer with truncate, minWidth, maxWidth, maxHeight",
+  },
 ] as const;
 
 type DemoId = (typeof demos)[number]["value"];
@@ -75,6 +82,8 @@ const runDemo = (id: DemoId) => {
       return textPromptDemo;
     case "perlin":
       return perlinDemo;
+    case "log-viewer":
+      return logViewerDemo;
   }
 };
 
@@ -83,7 +92,7 @@ const root = Command.make(
   {
     run: Flag.integer("run").pipe(
       Flag.optional,
-      Flag.withDescription("Run a demo by number (1-8)")
+      Flag.withDescription("Run a demo by number (1-9)")
     ),
   },
   ({ run }) =>

--- a/scratchpad/04-ansi-demo.ts
+++ b/scratchpad/04-ansi-demo.ts
@@ -74,14 +74,29 @@ const bgColors = [
 
 // Bright background
 const bgBrightColors = [
-  { name: "bgBrightBlack", style: Ansi.combine(Ansi.white, Ansi.bgBrightBlack) },
+  {
+    name: "bgBrightBlack",
+    style: Ansi.combine(Ansi.white, Ansi.bgBrightBlack),
+  },
   { name: "bgBrightRed", style: Ansi.combine(Ansi.black, Ansi.bgBrightRed) },
-  { name: "bgBrightGreen", style: Ansi.combine(Ansi.black, Ansi.bgBrightGreen) },
-  { name: "bgBrightYellow", style: Ansi.combine(Ansi.black, Ansi.bgBrightYellow) },
+  {
+    name: "bgBrightGreen",
+    style: Ansi.combine(Ansi.black, Ansi.bgBrightGreen),
+  },
+  {
+    name: "bgBrightYellow",
+    style: Ansi.combine(Ansi.black, Ansi.bgBrightYellow),
+  },
   { name: "bgBrightBlue", style: Ansi.combine(Ansi.black, Ansi.bgBrightBlue) },
-  { name: "bgBrightMagenta", style: Ansi.combine(Ansi.black, Ansi.bgBrightMagenta) },
+  {
+    name: "bgBrightMagenta",
+    style: Ansi.combine(Ansi.black, Ansi.bgBrightMagenta),
+  },
   { name: "bgBrightCyan", style: Ansi.combine(Ansi.black, Ansi.bgBrightCyan) },
-  { name: "bgBrightWhite", style: Ansi.combine(Ansi.black, Ansi.bgBrightWhite) },
+  {
+    name: "bgBrightWhite",
+    style: Ansi.combine(Ansi.black, Ansi.bgBrightWhite),
+  },
 ];
 
 // Text attributes

--- a/scratchpad/09-log-viewer.ts
+++ b/scratchpad/09-log-viewer.ts
@@ -1,0 +1,355 @@
+import { BunServices } from "@effect/platform-bun";
+import {
+  Data,
+  Duration,
+  Effect,
+  Fiber,
+  HashMap,
+  Option,
+  pipe,
+  Ref,
+  Schedule,
+  Stream,
+  Terminal,
+} from "effect";
+import { Prompt } from "effect/unstable/cli";
+import { Reactive } from "../src";
+import * as Ansi from "../src/Ansi";
+import * as Box from "../src/Box";
+import * as Cmd from "../src/Cmd";
+
+// ----------------------------------------------------------------------------
+// Types
+// ----------------------------------------------------------------------------
+
+type LogViewerState = {
+  readonly lines: ReadonlyArray<string>;
+  readonly scrollOffset: number;
+  readonly autoScroll: boolean;
+};
+
+interface LogViewerOptions {
+  readonly title: string;
+  readonly height?: number;
+  readonly stream: Stream.Stream<string>;
+}
+
+const Action = Data.taggedEnum<Prompt.ActionDefinition>();
+
+// ----------------------------------------------------------------------------
+// Constants
+// ----------------------------------------------------------------------------
+
+const DEFAULT_HEIGHT = 16;
+
+const getTermWidth = (): number => {
+  try {
+    return process.stdout.columns ?? 80;
+  } catch {
+    return 80;
+  }
+};
+
+// ----------------------------------------------------------------------------
+// Rendering
+// ----------------------------------------------------------------------------
+
+const renderLayout = (
+  state: LogViewerState,
+  title: string,
+  height: number,
+  submitted: boolean
+) =>
+  Effect.gen(function* () {
+    const terminal = yield* Terminal.Terminal;
+    const termWidth = yield* terminal.columns;
+    const innerWidth = termWidth - 4; // border + padding
+
+    if (submitted) {
+      return Box.hsep(
+        [
+          Box.text("✔").pipe(Box.annotate(Ansi.green)),
+          Box.text(title).pipe(Box.annotate(Ansi.bold)),
+          Box.text(`(${state.lines.length} lines)`).pipe(
+            Box.annotate(Ansi.dim)
+          ),
+        ],
+        1,
+        Box.top
+      );
+    }
+
+    // Compute visible window
+    const totalLines = state.lines.length;
+    const visibleLines = state.lines.slice(
+      state.scrollOffset,
+      state.scrollOffset + height
+    );
+
+    // Build content box
+    const contentBox =
+      visibleLines.length === 0
+        ? Box.text("Waiting for log data...").pipe(Box.annotate(Ansi.dim))
+        : pipe(
+            visibleLines.map((line) => colorLogLine(line)),
+            (boxes) => Box.vcat(boxes, Box.left)
+          );
+
+    // Apply constraints: fixed height, max width with truncation
+    const constrainedContent = pipe(
+      contentBox,
+      Box.minHeight(height),
+      Box.maxHeight(height),
+      Box.minWidth(innerWidth),
+      Box.truncate(innerWidth, Box.left)
+    );
+
+    // Header
+    const header = Box.hsep(
+      [
+        Box.text(`  ${title}`).pipe(Box.annotate(Ansi.bold)),
+        Box.text(
+          `[${Math.min(state.scrollOffset + 1, totalLines)}–${Math.min(state.scrollOffset + height, totalLines)} / ${totalLines}]`
+        ).pipe(Box.annotate(Ansi.dim)),
+      ],
+      1,
+      Box.top
+    );
+
+    // Footer
+    const scrollIndicator = state.autoScroll
+      ? Box.text("AUTO").pipe(Box.annotate(Ansi.green))
+      : Box.text("MANUAL").pipe(Box.annotate(Ansi.yellow));
+
+    const footer = Box.hsep(
+      [
+        Box.text("  ↑/↓ scroll").pipe(Box.annotate(Ansi.dim)),
+        Box.text("·").pipe(Box.annotate(Ansi.dim)),
+        scrollIndicator,
+        Box.text("·").pipe(Box.annotate(Ansi.dim)),
+        Box.text("enter exit").pipe(Box.annotate(Ansi.dim)),
+      ],
+      1,
+      Box.top
+    );
+
+    return Box.vcat(
+      [
+        header,
+        constrainedContent.pipe(Box.pad(0, 1), Box.border("rounded")),
+        footer,
+      ],
+      Box.left
+    );
+  });
+
+// Simple log-level coloring
+const colorLogLine = (line: string): Box.Box<Ansi.AnsiStyle> => {
+  if (line.includes("[ERROR]") || line.includes("[FATAL]")) {
+    return Box.text(line).pipe(Box.annotate(Ansi.red));
+  }
+  if (line.includes("[WARN]")) {
+    return Box.text(line).pipe(Box.annotate(Ansi.yellow));
+  }
+  if (line.includes("[DEBUG]")) {
+    return Box.text(line).pipe(Box.annotate(Ansi.dim));
+  }
+  if (line.includes("[INFO]")) {
+    return Box.text(line).pipe(Box.annotate(Ansi.cyan));
+  }
+  return Box.text(line);
+};
+
+// ----------------------------------------------------------------------------
+// LogViewer Prompt
+// ----------------------------------------------------------------------------
+
+export const LogViewer = ({
+  title,
+  height = DEFAULT_HEIGHT,
+  stream,
+}: LogViewerOptions) => {
+  return Effect.gen(function* () {
+    // Shared ref for accumulated log lines
+    const linesRef = yield* Ref.make<ReadonlyArray<string>>([]);
+
+    // Fork background fiber to consume stream
+    const fiber = yield* Stream.runForEach(stream, (line) =>
+      Ref.update(linesRef, (lines) => [...lines, line])
+    ).pipe(Effect.forkChild);
+
+    const prompt = Prompt.custom<LogViewerState, string>(
+      {
+        lines: [],
+        scrollOffset: 0,
+        autoScroll: true,
+      },
+      {
+        render: (
+          _state: LogViewerState,
+          action: Prompt.Action<LogViewerState, string>
+        ) =>
+          Action.$match(action, {
+            Beep: () => Effect.succeed(""),
+
+            NextFrame: ({ state: nextState }) =>
+              Effect.gen(function* () {
+                const layout = yield* renderLayout(
+                  nextState,
+                  title,
+                  height,
+                  false
+                );
+                return Box.renderPrettySync(layout);
+              }),
+
+            Submit: () =>
+              Effect.gen(function* () {
+                const layout = yield* renderLayout(
+                  { lines: [], scrollOffset: 0, autoScroll: true },
+                  title,
+                  height,
+                  true
+                );
+                return Box.renderPrettySync(
+                  layout.pipe(Box.vAppend<Ansi.AnsiStyle>(Box.text("")))
+                );
+              }),
+          }),
+
+        process: (input, state) =>
+          Effect.gen(function* () {
+            // Read latest lines from the background fiber
+            const currentLines = yield* Ref.get(linesRef);
+            const maxOffset = Math.max(0, currentLines.length - height);
+
+            // Base state with latest lines
+            const base: LogViewerState = {
+              ...state,
+              lines: currentLines as string[],
+            };
+
+            switch (input.key.name) {
+              case "up": {
+                const newOffset = Math.max(0, base.scrollOffset - 1);
+                return Action.NextFrame({
+                  state: {
+                    ...base,
+                    scrollOffset: newOffset,
+                    autoScroll: false,
+                  },
+                });
+              }
+
+              case "down": {
+                const newOffset = Math.min(maxOffset, base.scrollOffset + 1);
+                const atBottom = newOffset >= maxOffset;
+                return Action.NextFrame({
+                  state: {
+                    ...base,
+                    scrollOffset: newOffset,
+                    autoScroll: atBottom,
+                  },
+                });
+              }
+
+              case "enter":
+              case "return":
+                return Action.Submit({ value: "done" });
+
+              default: {
+                const offset = base.autoScroll
+                  ? maxOffset
+                  : Math.min(base.scrollOffset, maxOffset);
+                return Action.NextFrame({
+                  state: { ...base, scrollOffset: offset },
+                });
+              }
+            }
+          }),
+
+        clear: (state: LogViewerState, _action) =>
+          Effect.gen(function* () {
+            const layout = yield* renderLayout(state, title, height, false);
+
+            return Box.renderPrettySync(Cmd.clearLines(layout.rows));
+          }),
+      }
+    );
+
+    const result = yield* prompt;
+
+    // Clean up background fiber
+    yield* Fiber.interrupt(fiber);
+
+    return result;
+  });
+};
+
+// ----------------------------------------------------------------------------
+// Demo: Fake log stream
+// ----------------------------------------------------------------------------
+
+const logMessages = [
+  "[INFO]  Application starting up...",
+  "[INFO]  Loading configuration from /etc/app/config.yaml",
+  "[DEBUG] Config keys found: database, cache, auth, logging",
+  "[INFO]  Connecting to PostgreSQL at db.internal:5432",
+  "[INFO]  Database connection established (pool: 10)",
+  "[INFO]  Initializing Redis cache at cache.internal:6379",
+  "[WARN]  Redis connection slow (latency: 120ms > threshold: 100ms)",
+  "[INFO]  Cache warmed with 1,247 entries",
+  "[INFO]  Starting HTTP server on :8080",
+  "[INFO]  Registered 24 API routes",
+  "[DEBUG] Route: GET  /api/v1/users",
+  "[DEBUG] Route: POST /api/v1/users",
+  "[DEBUG] Route: GET  /api/v1/users/:id",
+  "[DEBUG] Route: PUT  /api/v1/users/:id",
+  "[INFO]  Health check endpoint: /healthz",
+  "[INFO]  Server ready, accepting connections",
+  "[INFO]  Incoming request: GET /api/v1/users (client: 10.0.1.42)",
+  "[INFO]  Response: 200 OK (23ms)",
+  "[WARN]  Rate limit approaching for client 10.0.1.42 (85/100 req/min)",
+  "[INFO]  Incoming request: POST /api/v1/users (client: 10.0.1.55)",
+  "[INFO]  Response: 201 Created (45ms)",
+  "[ERROR] Query timeout: SELECT * FROM analytics WHERE date > '2024-01-01'",
+  "[WARN]  Retrying query (attempt 2/3)...",
+  "[INFO]  Query succeeded on retry (1,203ms)",
+  "[INFO]  Incoming request: GET /api/v1/users/42 (client: 10.0.1.42)",
+  "[INFO]  Cache HIT for user:42",
+  "[INFO]  Response: 200 OK (2ms)",
+  "[DEBUG] GC pause: 12ms (heap: 245MB / 512MB)",
+  "[INFO]  Scheduled job: cleanup_sessions started",
+  "[INFO]  Cleaned 342 expired sessions",
+  "[WARN]  Disk usage at 78% on /var/data",
+  "[INFO]  Incoming request: PUT /api/v1/users/42 (client: 10.0.1.42)",
+  "[INFO]  Response: 200 OK (31ms)",
+  "[ERROR] Connection reset by peer: cache.internal:6379",
+  "[WARN]  Redis reconnecting (attempt 1/5)...",
+  "[INFO]  Redis reconnected successfully",
+  "[INFO]  Cache re-synced (delta: 23 entries)",
+  "[INFO]  Incoming request: GET /api/v1/users?page=2 (client: 10.0.1.88)",
+  "[INFO]  Response: 200 OK (18ms)",
+  "[FATAL] Out of memory: heap limit reached (512MB)",
+  "[INFO]  Initiating graceful shutdown...",
+  "[INFO]  Draining 3 active connections...",
+  "[INFO]  All connections drained",
+  "[INFO]  Closing database pool...",
+  "[INFO]  Database pool closed",
+  "[INFO]  Shutdown complete",
+];
+
+const fakeLogStream: Stream.Stream<string> = pipe(
+  Stream.fromIterable(logMessages),
+  Stream.schedule(Schedule.spaced(Duration.millis(300)))
+);
+
+// ----------------------------------------------------------------------------
+// Main
+// ----------------------------------------------------------------------------
+
+export const main = LogViewer({
+  title: "Application Logs",
+  height: 10,
+  stream: fakeLogStream,
+}).pipe(Effect.provide(BunServices.layer));

--- a/src/Box.ts
+++ b/src/Box.ts
@@ -1586,3 +1586,89 @@ export const pad: {
     left: number
   ): Box<A>;
 } = internal.pad;
+
+/**
+ * Ensures a box is at least `n` columns wide, padding with spaces on the right
+ * if the box is narrower.
+ *
+ * **Example**
+ *
+ * ```typescript
+ * import { pipe } from "effect"
+ * import * as Box from "effect-boxes/Box"
+ *
+ * const result = pipe(Box.text("Hi"), Box.minWidth(10))
+ * console.log(Box.cols(result))
+ * // 10
+ * ```
+ *
+ * @category transformations
+ */
+export const minWidth: {
+  (n: number): <A>(self: Box<A>) => Box<A>;
+  <A>(self: Box<A>, n: number): Box<A>;
+} = internal.minWidth;
+
+/**
+ * Caps a box at `n` columns wide, truncating lines that exceed the limit.
+ *
+ * **Example**
+ *
+ * ```typescript
+ * import { pipe } from "effect"
+ * import * as Box from "effect-boxes/Box"
+ *
+ * const result = pipe(Box.text("Hello World"), Box.maxWidth(5))
+ * console.log(Box.cols(result))
+ * // 5
+ * ```
+ *
+ * @category transformations
+ */
+export const maxWidth: {
+  (n: number): <A>(self: Box<A>) => Box<A>;
+  <A>(self: Box<A>, n: number): Box<A>;
+} = internal.maxWidth;
+
+/**
+ * Ensures a box is at least `n` rows tall, padding with blank rows at the
+ * bottom if the box is shorter.
+ *
+ * **Example**
+ *
+ * ```typescript
+ * import { pipe } from "effect"
+ * import * as Box from "effect-boxes/Box"
+ *
+ * const result = pipe(Box.text("X"), Box.minHeight(5))
+ * console.log(Box.rows(result))
+ * // 5
+ * ```
+ *
+ * @category transformations
+ */
+export const minHeight: {
+  (n: number): <A>(self: Box<A>) => Box<A>;
+  <A>(self: Box<A>, n: number): Box<A>;
+} = internal.minHeight;
+
+/**
+ * Caps a box at `n` rows tall, keeping only the first `n` rows.
+ *
+ * **Example**
+ *
+ * ```typescript
+ * import { pipe } from "effect"
+ * import * as Box from "effect-boxes/Box"
+ *
+ * const result = pipe(Box.text("A\nB\nC\nD\nE"), Box.maxHeight(3))
+ * console.log(Box.rows(result))
+ * // 3
+ * ```
+ *
+ * @category transformations
+ */
+export const maxHeight: {
+  (n: number): <A>(self: Box<A>) => Box<A>;
+  <A>(self: Box<A>, n: number): Box<A>;
+} = internal.maxHeight;

--- a/src/internal/box.ts
+++ b/src/internal/box.ts
@@ -1206,13 +1206,58 @@ export const pad = dual<
 // --------------------------------------------------------------------------------
 
 /** @internal */
+const truncateWidth = <A>(
+  self: Box.Box<A>,
+  width: number,
+  onText: (text: string) => Box.Box<A>
+): Box.Box<A> => {
+  if (self.cols <= width) return self;
+
+  const go = (box: Box.Box<A>): Box.Box<A> =>
+    match(box, {
+      blank: () => emptyBox(box.rows, width),
+      text: (t) => onText(t),
+      row: () =>
+        go(
+          make({
+            rows: box.rows,
+            cols: box.cols,
+            content: { _tag: "SubBox", xAlign: left, yAlign: top, box },
+          })
+        ),
+      col: (boxes) =>
+        make({
+          rows: box.rows,
+          cols: width,
+          content: { _tag: "Col", boxes: boxes.map(go) },
+          annotation: box.annotation,
+        }),
+      subBox: (inner, xAlign, yAlign) =>
+        make({
+          rows: box.rows,
+          cols: width,
+          content: { _tag: "SubBox", xAlign, yAlign, box: go(inner) },
+          annotation: box.annotation,
+        }),
+    });
+
+  const result = go(self);
+  if (self.annotation && !result.annotation) {
+    return make({
+      rows: result.rows,
+      cols: result.cols,
+      content: result.content,
+      annotation: self.annotation,
+    });
+  }
+  return result;
+};
+
+/** @internal */
 export const truncate = dual<
   (width: number, pos: Box.Alignment) => <A>(self: Box.Box<A>) => Box.Box<A>,
   <A>(self: Box.Box<A>, width: number, pos: Box.Alignment) => Box.Box<A>
 >(3, <A>(self: Box.Box<A>, width: number, pos: Box.Alignment): Box.Box<A> => {
-  // No truncation needed
-  if (self.cols <= width) return self;
-
   const ellipsis = "…";
 
   const truncateLine = (text: string): Box.Box<A> => {
@@ -1254,48 +1299,52 @@ export const truncate = dual<
     );
   };
 
-  const go = (box: Box.Box<A>): Box.Box<A> =>
-    match(box, {
-      blank: () => box,
-      text: (t) => truncateLine(t),
-      row: () =>
-        go(
-          make({
-            rows: box.rows,
-            cols: box.cols,
-            content: { _tag: "SubBox", xAlign: left, yAlign: top, box },
-          })
-        ),
-      col: (boxes) =>
-        make({
-          rows: box.rows,
-          cols: width,
-          content: { _tag: "Col", boxes: boxes.map(go) },
-          annotation: box.annotation,
-        }),
-      subBox: (inner, xAlign, yAlign) =>
-        make({
-          rows: box.rows,
-          cols: width,
-          content: {
-            _tag: "SubBox",
-            xAlign,
-            yAlign,
-            box: go(inner),
-          },
-          annotation: box.annotation,
-        }),
-    });
+  return truncateWidth(self, width, truncateLine);
+});
 
-  const result = go(self);
-  // Preserve top-level annotation
-  if (self.annotation && !result.annotation) {
-    return make({
-      rows: result.rows,
-      cols: result.cols,
-      content: result.content,
-      annotation: self.annotation,
-    });
-  }
-  return result;
+/** @internal */
+export const minWidth = dual<
+  (n: number) => <A>(self: Box.Box<A>) => Box.Box<A>,
+  <A>(self: Box.Box<A>, n: number) => Box.Box<A>
+>(
+  2,
+  <A>(self: Box.Box<A>, n: number): Box.Box<A> =>
+    self.cols >= n ? self : alignHoriz(self, left, n)
+);
+
+/** @internal */
+export const maxWidth = dual<
+  (n: number) => <A>(self: Box.Box<A>) => Box.Box<A>,
+  <A>(self: Box.Box<A>, n: number) => Box.Box<A>
+>(
+  2,
+  <A>(self: Box.Box<A>, n: number): Box.Box<A> =>
+    truncateWidth(self, n, (t) =>
+      unsafeLine(Width.segments(t).slice(0, n).join(""))
+    )
+);
+
+/** @internal */
+export const minHeight = dual<
+  (n: number) => <A>(self: Box.Box<A>) => Box.Box<A>,
+  <A>(self: Box.Box<A>, n: number) => Box.Box<A>
+>(
+  2,
+  <A>(self: Box.Box<A>, n: number): Box.Box<A> =>
+    self.rows >= n ? self : alignVert(self, top, n)
+);
+
+/** @internal */
+export const maxHeight = dual<
+  (n: number) => <A>(self: Box.Box<A>) => Box.Box<A>,
+  <A>(self: Box.Box<A>, n: number) => Box.Box<A>
+>(2, <A>(self: Box.Box<A>, n: number): Box.Box<A> => {
+  if (self.rows <= n) return self;
+
+  return make({
+    rows: n,
+    cols: self.cols,
+    content: { _tag: "SubBox", xAlign: left, yAlign: top, box: self },
+    annotation: self.annotation,
+  });
 });

--- a/tests/constraints.test.ts
+++ b/tests/constraints.test.ts
@@ -1,0 +1,151 @@
+import { pipe } from "effect";
+import { describe, expect, it } from "vitest";
+import * as Box from "../src/Box";
+
+/** Replace spaces with dots for visible whitespace in assertions */
+const dots = (s: string) => s.replaceAll(" ", ".");
+
+describe("Box.minWidth", () => {
+  it("pads a narrow box to the target width", () => {
+    const result = pipe(Box.text("Hi"), Box.minWidth(10));
+    expect(Box.cols(result)).toBe(10);
+    expect(Box.rows(result)).toBe(1);
+  });
+
+  it("is a no-op when box is already wider", () => {
+    const result = pipe(Box.text("Hello World"), Box.minWidth(5));
+    expect(Box.cols(result)).toBe(11);
+  });
+
+  it("is a no-op when box equals target width", () => {
+    const result = pipe(Box.text("ABC"), Box.minWidth(3));
+    expect(Box.cols(result)).toBe(3);
+  });
+
+  it("pads with spaces on the right (left-aligned)", () => {
+    const result = pipe(Box.text("Hi"), Box.minWidth(5));
+    expect(dots(Box.renderPlainSync(result))).toBe("Hi...");
+  });
+
+  it("works with multi-line boxes", () => {
+    const result = pipe(Box.text("A\nBC"), Box.minWidth(5));
+    expect(Box.cols(result)).toBe(5);
+    expect(Box.rows(result)).toBe(2);
+  });
+
+  it("supports data-first usage", () => {
+    const result = Box.minWidth(Box.text("Hi"), 10);
+    expect(Box.cols(result)).toBe(10);
+  });
+});
+
+describe("Box.maxWidth", () => {
+  it("truncates a wide box to the target width", () => {
+    const result = pipe(Box.text("Hello World"), Box.maxWidth(5));
+    expect(Box.cols(result)).toBe(5);
+  });
+
+  it("is a no-op when box is already narrower", () => {
+    const result = pipe(Box.text("Hi"), Box.maxWidth(10));
+    expect(Box.cols(result)).toBe(2);
+  });
+
+  it("is a no-op when box equals target width", () => {
+    const result = pipe(Box.text("ABC"), Box.maxWidth(3));
+    expect(Box.cols(result)).toBe(3);
+  });
+
+  it("truncates content correctly", () => {
+    const result = pipe(Box.text("Hello World"), Box.maxWidth(5));
+    expect(Box.renderPlainSync(result)).toBe("Hello");
+  });
+
+  it("truncates each line of a multi-line box", () => {
+    const result = pipe(Box.text("Hello\nWorld!"), Box.maxWidth(3));
+    expect(Box.renderPlainSync(result)).toBe("Hel\nWor");
+  });
+
+  it("supports data-first usage", () => {
+    const result = Box.maxWidth(Box.text("Hello World"), 5);
+    expect(Box.cols(result)).toBe(5);
+  });
+});
+
+describe("Box.minHeight", () => {
+  it("pads a short box to the target height", () => {
+    const result = pipe(Box.text("X"), Box.minHeight(5));
+    expect(Box.rows(result)).toBe(5);
+    expect(Box.cols(result)).toBe(1);
+  });
+
+  it("is a no-op when box is already taller", () => {
+    const result = pipe(Box.text("A\nB\nC\nD\nE"), Box.minHeight(3));
+    expect(Box.rows(result)).toBe(5);
+  });
+
+  it("is a no-op when box equals target height", () => {
+    const result = pipe(Box.text("A\nB"), Box.minHeight(2));
+    expect(Box.rows(result)).toBe(2);
+  });
+
+  it("pads with blank rows at the bottom (top-aligned)", () => {
+    const result = pipe(Box.text("X"), Box.minHeight(3));
+    expect(dots(Box.renderPlainSync(result))).toBe("X\n.\n.");
+  });
+
+  it("supports data-first usage", () => {
+    const result = Box.minHeight(Box.text("X"), 5);
+    expect(Box.rows(result)).toBe(5);
+  });
+});
+
+describe("Box.maxHeight", () => {
+  it("truncates a tall box to the target height", () => {
+    const result = pipe(Box.text("A\nB\nC\nD\nE"), Box.maxHeight(3));
+    expect(Box.rows(result)).toBe(3);
+  });
+
+  it("is a no-op when box is already shorter", () => {
+    const result = pipe(Box.text("A\nB"), Box.maxHeight(5));
+    expect(Box.rows(result)).toBe(2);
+  });
+
+  it("is a no-op when box equals target height", () => {
+    const result = pipe(Box.text("A\nB\nC"), Box.maxHeight(3));
+    expect(Box.rows(result)).toBe(3);
+  });
+
+  it("keeps only the first n rows", () => {
+    const result = pipe(Box.text("A\nB\nC\nD\nE"), Box.maxHeight(3));
+    expect(Box.renderPlainSync(result)).toBe("A\nB\nC");
+  });
+
+  it("supports data-first usage", () => {
+    const result = Box.maxHeight(Box.text("A\nB\nC\nD\nE"), 2);
+    expect(Box.rows(result)).toBe(2);
+  });
+});
+
+describe("constraints composition", () => {
+  it("minWidth + maxWidth clamps to exact width", () => {
+    const result = pipe(Box.text("Hi"), Box.minWidth(10), Box.maxWidth(10));
+    expect(Box.cols(result)).toBe(10);
+  });
+
+  it("minHeight + maxHeight clamps to exact height", () => {
+    const result = pipe(Box.text("X"), Box.minHeight(5), Box.maxHeight(5));
+    expect(Box.rows(result)).toBe(5);
+  });
+
+  it("all four constraints can be composed", () => {
+    const result = pipe(
+      Box.text("Hi"),
+      Box.minWidth(10),
+      Box.maxWidth(20),
+      Box.minHeight(3),
+      Box.maxHeight(5)
+    );
+    expect(Box.cols(result)).toBe(10);
+    expect(Box.rows(result)).toBe(3);
+  });
+});


### PR DESCRIPTION
## Goal/Scope

Add combinators to enforce minimum and maximum dimensions on a box, enabling responsive-like layouts in fixed-width terminals.

## Description

Four new functions enforce minimum and maximum dimensions on a box:

- `Box.minWidth(n)` -- pads with spaces to ensure at least n columns
- `Box.maxWidth(n)` -- hard-truncates lines exceeding n columns
- `Box.minHeight(n)` -- pads with blank rows to ensure at least n rows
- `Box.maxHeight(n)` -- keeps only the first n rows

## Comment

The minWidth turned out to be very similar to the truncate just without the ellipse character logic so have extracted this into some shared logic, might be some additonal refactoring later on