### PR TITLE
feat: add Ansi.colorHex for building colors from hex strings

### DIFF
--- a/.changeset/major-canyons-fail.md
+++ b/.changeset/major-canyons-fail.md
@@ -1,0 +1,28 @@
+---
+"effect-boxes": minor
+---
+
+Add `Ansi.colorHex` and `Ansi.bgColorHex` for building colors from hex strings, closes #45
+
+Supports 3-digit shorthand, 6-digit, with or without `#` prefix, and is case-insensitive. Throws on invalid input.
+
+```typescript
+import { pipe } from "effect"
+import * as Box from "effect-boxes/Box"
+import * as Ansi from "effect-boxes/Ansi"
+
+// Foreground from hex
+const branded = pipe(
+  Box.text("Acme Corp"),
+  Box.annotate(Ansi.colorHex("#ff6600"))
+)
+
+// Background from hex
+const highlight = pipe(
+  Box.text("Important"),
+  Box.annotate(Ansi.combine(Ansi.colorHex("#ffffff"), Ansi.bgColorHex("#8b5cf6")))
+)
+
+// Short-form hex
+const short = Ansi.colorHex("#f60") // equivalent to #ff6600
+```

--- a/docs/using-annotation.md
+++ b/docs/using-annotation.md
@@ -180,6 +180,17 @@ const styledBox = pipe(
   Box.text("Important"),
   Box.annotate(Ansi.combine(Ansi.bold, Ansi.underlined, Ansi.red))
 );
+
+// Use hex colors for foreground and background
+const hexColoredBox = pipe(
+  Box.text("Custom Color"),
+  Box.annotate(Ansi.colorHex("#ff6600"))
+);
+
+const hexBgBox = pipe(
+  Box.text("Highlighted"),
+  Box.annotate(Ansi.combine(Ansi.colorHex("#ffffff"), Ansi.bgColorHex("#333333")))
+);
 ```
 
 ## Advanced Usage

--- a/src/Ansi.ts
+++ b/src/Ansi.ts
@@ -192,6 +192,8 @@ export const color256: (n: number) => AnsiAnnotation = internal.color256;
 export const colorRGB: (r: number, g: number, b: number) => AnsiAnnotation =
   internal.colorRGB;
 
+export const colorHex: (hex: string) => AnsiAnnotation = internal.colorHex;
+
 /**
  * Black background color.
  *
@@ -346,6 +348,8 @@ export const bgColor256: (n: number) => AnsiAnnotation = internal.bgColor256;
  */
 export const bgColorRGB: (r: number, g: number, b: number) => AnsiAnnotation =
   internal.bgColorRGB;
+
+export const bgColorHex: (hex: string) => AnsiAnnotation = internal.bgColorHex;
 
 //
 // --------------------------------------------------------------------------------

--- a/src/internal/ansi.ts
+++ b/src/internal/ansi.ts
@@ -54,6 +54,24 @@ export const cyan = makeForegroundColor("cyan", "36");
 export const white = makeForegroundColor("white", "37");
 export const fgDefault = makeForegroundColor("default", "39");
 const clampColor = (n: number): number => Math.min(255, Math.max(0, n));
+const makeHexColor = (hex: string): [number, number, number] => {
+  // Expand shorthand form (e.g. "03F") to full form (e.g. "0033FF")
+  const shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
+  const fullHex = hex.replace(
+    shorthandRegex,
+    (_, r, g, b) => r + r + g + g + b + b
+  );
+  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(fullHex);
+  const rs = result?.[1];
+  const gs = result?.[2];
+  const bs = result?.[3];
+
+  if (rs === undefined || gs === undefined || bs === undefined) {
+    throw new Error(`Invalid hex color: ${hex}`);
+  }
+
+  return [parseInt(rs, 16), parseInt(gs, 16), parseInt(bs, 16)];
+};
 export const color256 = (n: number): Ansi.AnsiAnnotation =>
   makeForegroundColor(`color256(${clampColor(n)})`, `38;5;${clampColor(n)}`);
 export const colorRGB = (
@@ -65,6 +83,11 @@ export const colorRGB = (
     `rgb(${clampColor(r)},${clampColor(g)},${clampColor(b)})`,
     `38;2;${clampColor(r)};${clampColor(g)};${clampColor(b)}`
   );
+
+export const colorHex = (hex: string): Ansi.AnsiAnnotation => {
+  const [r, g, b] = makeHexColor(hex);
+  return colorRGB(r, g, b);
+};
 
 //
 // Background color constants - aliases to the main color constants
@@ -90,6 +113,11 @@ export const bgColorRGB = (
     `rgb(${clampColor(r)},${clampColor(g)},${clampColor(b)})`,
     `48;2;${clampColor(r)};${clampColor(g)};${clampColor(b)}`
   );
+
+export const bgColorHex = (hex: string): Ansi.AnsiAnnotation => {
+  const [r, g, b] = makeHexColor(hex);
+  return bgColorRGB(r, g, b);
+};
 
 // Bright foreground colors (SGR 90-97)
 export const brightBlack = makeForegroundColor("brightBlack", "90");

--- a/tests/ansi.test.ts
+++ b/tests/ansi.test.ts
@@ -107,7 +107,7 @@ describe("Ansi Module", () => {
     });
   });
 
-  describe("256 and RGB Colors", () => {
+  describe("256, RGB and Hex Colors", () => {
     it("should generate correct escape sequence for color256", () => {
       const color = Ansi.color256(100);
       const styledBox = Box.text("test").pipe(Box.annotate(color));
@@ -148,6 +148,70 @@ describe("Ansi Module", () => {
       const styledBox = Box.text("test").pipe(Box.annotate(color));
       const rendered = Ansi.renderAnnotatedBox(styledBox);
       expect(rendered.join("")).toContain("\u001b[38;2;255;0;255m");
+    });
+
+    it("should generate correct escape sequence for bgColorHex", () => {
+      const color = Ansi.bgColorHex("#FF00FF");
+      const styledBox = Box.text("test").pipe(Box.annotate(color));
+      const rendered = Ansi.renderAnnotatedBox(styledBox);
+      expect(rendered.join("")).toContain("\u001b[48;2;255;0;255m");
+    });
+
+    it("should generate correct escape sequence for colorHex", () => {
+      const color = Ansi.colorHex("#00FF00");
+      const styledBox = Box.text("test").pipe(Box.annotate(color));
+      const rendered = Ansi.renderAnnotatedBox(styledBox);
+      expect(rendered.join("")).toContain("\u001b[38;2;0;255;0m");
+    });
+
+    it("should handle short hex codes for bgColorHex", () => {
+      const color = Ansi.bgColorHex("#0F0");
+      const styledBox = Box.text("test").pipe(Box.annotate(color));
+      const rendered = Ansi.renderAnnotatedBox(styledBox);
+      expect(rendered.join("")).toContain("\u001b[48;2;0;255;0m");
+    });
+
+    it("should handle short hex codes for colorHex", () => {
+      const color = Ansi.colorHex("#F0F");
+      const styledBox = Box.text("test").pipe(Box.annotate(color));
+      const rendered = Ansi.renderAnnotatedBox(styledBox);
+      expect(rendered.join("")).toContain("\u001b[38;2;255;0;255m");
+    });
+
+    it("should handle hex without # prefix", () => {
+      const color = Ansi.colorHex("FF8800");
+      const styledBox = Box.text("test").pipe(Box.annotate(color));
+      const rendered = Ansi.renderAnnotatedBox(styledBox);
+      expect(rendered.join("")).toContain("\u001b[38;2;255;136;0m");
+    });
+
+    it("should handle lowercase hex", () => {
+      const color = Ansi.colorHex("#ff00ff");
+      const styledBox = Box.text("test").pipe(Box.annotate(color));
+      const rendered = Ansi.renderAnnotatedBox(styledBox);
+      expect(rendered.join("")).toContain("\u001b[38;2;255;0;255m");
+    });
+
+    it("should parse #000000 as all zeros", () => {
+      const color = Ansi.colorHex("#000000");
+      const styledBox = Box.text("test").pipe(Box.annotate(color));
+      const rendered = Ansi.renderAnnotatedBox(styledBox);
+      expect(rendered.join("")).toContain("\u001b[38;2;0;0;0m");
+    });
+
+    it("should parse #FFFFFF as all 255s", () => {
+      const color = Ansi.colorHex("#FFFFFF");
+      const styledBox = Box.text("test").pipe(Box.annotate(color));
+      const rendered = Ansi.renderAnnotatedBox(styledBox);
+      expect(rendered.join("")).toContain("\u001b[38;2;255;255;255m");
+    });
+
+    it("should throw on invalid hex string", () => {
+      expect(() => Ansi.colorHex("xyz")).toThrow("Invalid hex color: xyz");
+    });
+
+    it("should throw on empty string", () => {
+      expect(() => Ansi.colorHex("")).toThrow("Invalid hex color: ");
     });
   });
 


### PR DESCRIPTION
## Goal/Scope

Add a convenience constructor that creates foreground/background colors from hex strings, matching the ergonomics of Lip Gloss, Ink, and Textual.

## Description

Supports 3-digit shorthand, 6-digit, with or without `#` prefix, and is case-insensitive. Throws on invalid input.
