### PR TITLE
docs: add JSDOCs for hex functions

### DIFF
--- a/src/Ansi.ts
+++ b/src/Ansi.ts
@@ -192,6 +192,26 @@ export const color256: (n: number) => AnsiAnnotation = internal.color256;
 export const colorRGB: (r: number, g: number, b: number) => AnsiAnnotation =
   internal.colorRGB;
 
+/**
+ * Creates a foreground color from a hex color string.
+ *
+ * Accepts hex strings with or without a leading `#`, in 3-digit or 6-digit
+ * format (e.g. `"#ff00ff"`, `"ff00ff"`, `"#f0f"`, `"f0f"`).
+ *
+ * @example
+ * ```typescript
+ * import * as Box from "effect-boxes/Box"
+ * import * as Ansi from "effect-boxes/Ansi"
+ *
+ * const coral = Ansi.colorHex("#FF6B6B")
+ * const styledText = Box.text("Coral text").pipe(
+ *   Box.annotate(coral)
+ * )
+ * console.log(Box.renderPrettySync(styledText))
+ * ```
+ *
+ * @category constructors
+ */
 export const colorHex: (hex: string) => AnsiAnnotation = internal.colorHex;
 
 /**
@@ -349,6 +369,26 @@ export const bgColor256: (n: number) => AnsiAnnotation = internal.bgColor256;
 export const bgColorRGB: (r: number, g: number, b: number) => AnsiAnnotation =
   internal.bgColorRGB;
 
+/**
+ * Creates a background color from a hex color string.
+ *
+ * Accepts hex strings with or without a leading `#`, in 3-digit or 6-digit
+ * format (e.g. `"#ff00ff"`, `"ff00ff"`, `"#f0f"`, `"f0f"`).
+ *
+ * @example
+ * ```typescript
+ * import * as Box from "effect-boxes/Box"
+ * import * as Ansi from "effect-boxes/Ansi"
+ *
+ * const warmBg = Ansi.bgColorHex("#FFE4B5")
+ * const styledText = Box.text("Warm background").pipe(
+ *   Box.annotate(warmBg)
+ * )
+ * console.log(Box.renderPrettySync(styledText))
+ * ```
+ *
+ * @category constructors
+ */
 export const bgColorHex: (hex: string) => AnsiAnnotation = internal.bgColorHex;
 
 //

--- a/src/Box.ts
+++ b/src/Box.ts
@@ -1039,8 +1039,7 @@ export const moveRight: {
  * When the box's width is already within the target width, the box is
  * returned unchanged. The ellipsis counts as one column toward the width.
  *
- * **Example**
- *
+ * @example
  * ```typescript
  * import { pipe } from "effect"
  * import * as Box from "effect-boxes/Box"
@@ -1591,8 +1590,7 @@ export const pad: {
  * Ensures a box is at least `n` columns wide, padding with spaces on the right
  * if the box is narrower.
  *
- * **Example**
- *
+ * @example
  * ```typescript
  * import { pipe } from "effect"
  * import * as Box from "effect-boxes/Box"
@@ -1612,8 +1610,7 @@ export const minWidth: {
 /**
  * Caps a box at `n` columns wide, truncating lines that exceed the limit.
  *
- * **Example**
- *
+ * @example
  * ```typescript
  * import { pipe } from "effect"
  * import * as Box from "effect-boxes/Box"
@@ -1634,8 +1631,7 @@ export const maxWidth: {
  * Ensures a box is at least `n` rows tall, padding with blank rows at the
  * bottom if the box is shorter.
  *
- * **Example**
- *
+ * @example
  * ```typescript
  * import { pipe } from "effect"
  * import * as Box from "effect-boxes/Box"
@@ -1655,8 +1651,7 @@ export const minHeight: {
 /**
  * Caps a box at `n` rows tall, keeping only the first `n` rows.
  *
- * **Example**
- *
+ * @example
  * ```typescript
  * import { pipe } from "effect"
  * import * as Box from "effect-boxes/Box"


### PR DESCRIPTION
## Goal/Scope

Forgot to add good JSDOCs for the new colorHex functions in ANSI.  Also fixing some issues with the new contraints functions in Box