### PR TITLE
fix: make Box<A> covariant in A

### DIFF
--- a/.changeset/tender-yaks-cough.md
+++ b/.changeset/tender-yaks-cough.md
@@ -1,0 +1,5 @@
+---
+"effect-boxes": patch
+---
+
+make Box<A> covariant in A, closes #66

--- a/src/Box.ts
+++ b/src/Box.ts
@@ -1,4 +1,4 @@
-import type { Effect } from "effect";
+import type { Effect, Types } from "effect";
 import type * as Equal from "effect/Equal";
 import type * as Hash from "effect/Hash";
 import type * as Inspectable from "effect/Inspectable";
@@ -123,12 +123,14 @@ export type BoxAnnotations<T extends readonly unknown[]> = T extends readonly [
  *
  * @category models
  */
-export interface Box<A = never>
+export interface Box<out A = never>
   extends Pipeable,
     Equal.Equal,
     Hash.Hash,
     Inspectable.Inspectable {
-  readonly [BoxTypeId]: BoxTypeId;
+  readonly [BoxTypeId]: {
+    readonly _A: Types.Covariant<A>;
+  };
   readonly rows: number;
   readonly cols: number;
   readonly content: Content<A>;
@@ -577,8 +579,8 @@ export const vcat: {
  * @category combinators
  */
 export const hAppend: {
-  <A>(that: Box<A>): (self: Box<A>) => Box<A>;
-  <A>(self: Box<A>, that: Box<A>): Box<A>;
+  <B>(that: Box<B>): <A>(self: Box<A>) => Box<A | B>;
+  <A, B>(self: Box<A>, that: Box<B>): Box<A | B>;
 } = internal.hAppend;
 
 /**
@@ -608,8 +610,8 @@ export const hAppend: {
  * @category combinators
  */
 export const hcatWithSpace: {
-  <A>(that: Box<A>): (self: Box<A>) => Box<A>;
-  <A>(self: Box<A>, that: Box<A>): Box<A>;
+  <B>(that: Box<B>): <A>(self: Box<A>) => Box<A | B>;
+  <A, B>(self: Box<A>, that: Box<B>): Box<A | B>;
 } = internal.hcatWithSpace;
 
 /**
@@ -634,8 +636,8 @@ export const hcatWithSpace: {
  * @category combinators
  */
 export const vAppend: {
-  <A>(that: Box<A>): (self: Box<A>) => Box<A>;
-  <A>(self: Box<A>, that: Box<A>): Box<A>;
+  <B>(that: Box<B>): <A>(self: Box<A>) => Box<A | B>;
+  <A, B>(self: Box<A>, that: Box<B>): Box<A | B>;
 } = internal.vAppend;
 
 /**
@@ -667,8 +669,8 @@ export const vAppend: {
  * @category combinators
  */
 export const vcatWithSpace: {
-  <A>(that: Box<A>): (self: Box<A>) => Box<A>;
-  <A>(self: Box<A>, that: Box<A>): Box<A>;
+  <B>(that: Box<B>): <A>(self: Box<A>) => Box<A | B>;
+  <A, B>(self: Box<A>, that: Box<B>): Box<A | B>;
 } = internal.vcatWithSpace;
 
 /**
@@ -1570,11 +1572,15 @@ export const asciiBorder: BorderChars = internal.asciiBorder;
  * @category combinators
  */
 export const border: {
-  <A>(
+  <B>(
     style?: BorderStyle,
-    options?: BorderOptions<A>
-  ): (self: Box<A>) => Box<A>;
-  <A>(self: Box<A>, style?: BorderStyle, options?: BorderOptions<A>): Box<A>;
+    options?: BorderOptions<B>
+  ): <A>(self: Box<A>) => Box<A | B>;
+  <A, B>(
+    self: Box<A>,
+    style?: BorderStyle,
+    options?: BorderOptions<B>
+  ): Box<A | B>;
 } = internal.border;
 
 // --------------------------------------------------------------------------------

--- a/src/internal/box.ts
+++ b/src/internal/box.ts
@@ -1,4 +1,13 @@
-import { Array, Equal, Hash, Inspectable, Match, pipe, String } from "effect";
+import {
+  Array,
+  Equal,
+  Function,
+  Hash,
+  Inspectable,
+  Match,
+  pipe,
+  String,
+} from "effect";
 import { dual } from "effect/Function";
 import { pipeArguments } from "effect/Pipeable";
 import type * as Annotation from "../Annotation";
@@ -62,7 +71,7 @@ const contentHash = <A>(box: Box.Box<A>): number =>
   });
 
 const proto: Omit<Box.Box, "rows" | "content" | "cols" | "annotation"> = {
-  [BoxTypeId]: BoxTypeId,
+  [BoxTypeId]: { _A: Function.identity },
   [Equal.symbol]<A>(this: Box.Box<A>, that: unknown): boolean {
     return (
       isBox<A>(that) &&
@@ -338,40 +347,41 @@ export const vcat = dual<
 
 /** @internal */
 export const hAppend = dual<
-  <A>(that: Box.Box<A>) => (self: Box.Box<A>) => Box.Box<A>,
-  <A>(self: Box.Box<A>, that: Box.Box<A>) => Box.Box<A>
+  <B>(that: Box.Box<B>) => <A>(self: Box.Box<A>) => Box.Box<A | B>,
+  <A, B>(self: Box.Box<A>, that: Box.Box<B>) => Box.Box<A | B>
 >(
   2,
-  <A>(self: Box.Box<A>, that: Box.Box<A>): Box.Box<A> => hcat([self, that], top)
+  <A, B>(self: Box.Box<A>, that: Box.Box<B>): Box.Box<A | B> =>
+    hcat([self, that], top)
 );
 
 /** @internal */
 export const hcatWithSpace = dual<
-  <A>(that: Box.Box<A>) => (self: Box.Box<A>) => Box.Box<A>,
-  <A>(self: Box.Box<A>, that: Box.Box<A>) => Box.Box<A>
+  <B>(that: Box.Box<B>) => <A>(self: Box.Box<A>) => Box.Box<A | B>,
+  <A, B>(self: Box.Box<A>, that: Box.Box<B>) => Box.Box<A | B>
 >(
   2,
-  <A>(self: Box.Box<A>, that: Box.Box<A>): Box.Box<A> =>
+  <A, B>(self: Box.Box<A>, that: Box.Box<B>): Box.Box<A | B> =>
     hcat([self, emptyBox(0, 1), that], top)
 );
 
 /** @internal */
 export const vAppend = dual<
-  <A>(that: Box.Box<A>) => (self: Box.Box<A>) => Box.Box<A>,
-  <A>(self: Box.Box<A>, that: Box.Box<A>) => Box.Box<A>
+  <B>(that: Box.Box<B>) => <A>(self: Box.Box<A>) => Box.Box<A | B>,
+  <A, B>(self: Box.Box<A>, that: Box.Box<B>) => Box.Box<A | B>
 >(
   2,
-  <A>(self: Box.Box<A>, that: Box.Box<A>): Box.Box<A> =>
+  <A, B>(self: Box.Box<A>, that: Box.Box<B>): Box.Box<A | B> =>
     vcat([self, that], left)
 );
 
 /** @internal */
 export const vcatWithSpace = dual<
-  <A>(that: Box.Box<A>) => (self: Box.Box<A>) => Box.Box<A>,
-  <A>(self: Box.Box<A>, that: Box.Box<A>) => Box.Box<A>
+  <B>(that: Box.Box<B>) => <A>(self: Box.Box<A>) => Box.Box<A | B>,
+  <A, B>(self: Box.Box<A>, that: Box.Box<B>) => Box.Box<A | B>
 >(
   2,
-  <A>(self: Box.Box<A>, that: Box.Box<A>): Box.Box<A> =>
+  <A, B>(self: Box.Box<A>, that: Box.Box<B>): Box.Box<A | B> =>
     vcat([self, emptyBox(1, 0), that], left)
 );
 
@@ -1048,31 +1058,31 @@ export interface BorderOptions<A> {
 
 /** @internal */
 export const border = dual<
-  <A>(
+  <B>(
     style?: BorderStyle,
-    options?: BorderOptions<A>
-  ) => (self: Box.Box<A>) => Box.Box<A>,
-  <A>(
+    options?: BorderOptions<B>
+  ) => <A>(self: Box.Box<A>) => Box.Box<A | B>,
+  <A, B>(
     self: Box.Box<A>,
     style?: BorderStyle,
-    options?: BorderOptions<A>
-  ) => Box.Box<A>
+    options?: BorderOptions<B>
+  ) => Box.Box<A | B>
 >(
   3,
-  <A>(
+  <A, B>(
     self: Box.Box<A>,
     style: BorderStyle = "single",
-    options?: BorderOptions<A>
-  ): Box.Box<A> => {
+    options?: BorderOptions<B>
+  ): Box.Box<A | B> => {
     const chars = borderStyleToChars(style);
 
-    const borderChar = (c: string): Box.Box<A> =>
+    const borderChar = (c: string): Box.Box<A | B> =>
       options?.annotation ? annotate(char(c), options.annotation) : char(c);
 
-    const borderText = (s: string): Box.Box<A> =>
+    const borderText = (s: string): Box.Box<A | B> =>
       options?.annotation ? annotate(text(s), options.annotation) : text(s);
 
-    const when = (cond: boolean, box: Box.Box<A>): Box.Box<A> =>
+    const when = (cond: boolean, box: Box.Box<A | B>): Box.Box<A | B> =>
       cond ? box : nullBox;
 
     const sideCol = vcat(

--- a/tests/box.test.ts
+++ b/tests/box.test.ts
@@ -1,10 +1,12 @@
 /** biome-ignore-all lint/suspicious/noExplicitAny: Testing runtime rather than build */
-import { String } from "effect";
+import { pipe, String } from "effect";
 import * as Equal from "effect/Equal";
 import * as Hash from "effect/Hash";
 import * as Inspectable from "effect/Inspectable";
 import { describe, expect, it } from "vitest";
 import * as Annotation from "../src/Annotation";
+import type { AnsiStyle } from "../src/Ansi";
+import * as Ansi from "../src/Ansi";
 import * as Box from "../src/Box";
 
 describe("Box", () => {
@@ -1200,4 +1202,59 @@ describe("Annotation Functions", () => {
     });
   });
 
+  describe("Covariance", () => {
+    it("border with annotation can be used in a generic pipeline", () => {
+      // With covariance, border can widen Box<A> to Box<A | AnsiStyle>
+      const panel = <A>(self: Box.Box<A>): Box.Box<A | AnsiStyle> =>
+        Box.border(self, "rounded", { annotation: Ansi.green });
+      const box = Box.text("hello");
+      const result = panel(box);
+      expect(result.rows).toBeGreaterThan(0);
+    });
+
+    it("Box<never> is assignable to Box<AnsiStyle>", () => {
+      const neverBox: Box.Box<never> = Box.text("hello");
+      const ansiBox: Box.Box<AnsiStyle> = neverBox;
+      expect(Box.renderPrettySync(ansiBox)).toBe("hello");
+    });
+
+    it("Box<AnsiStyle> is assignable to Box<unknown>", () => {
+      const styled: Box.Box<AnsiStyle> = pipe(
+        Box.text("styled"),
+        Box.border("rounded", { annotation: Ansi.green })
+      );
+      const wide: Box.Box<unknown> = styled;
+      expect(Box.renderPrettySync(wide)).toBeDefined();
+    });
+
+    it("hAppend composes Box<never> with Box<AnsiStyle>", () => {
+      const plain: Box.Box<never> = Box.text("left");
+      const styled: Box.Box<AnsiStyle> = pipe(
+        Box.text("right"),
+        Box.border("rounded", { annotation: Ansi.green })
+      );
+      const result: Box.Box<AnsiStyle> = Box.hAppend(plain, styled);
+      expect(result.cols).toBeGreaterThan(0);
+    });
+
+    it("vAppend composes Box<never> with Box<AnsiStyle>", () => {
+      const plain: Box.Box<never> = Box.text("top");
+      const styled: Box.Box<AnsiStyle> = pipe(
+        Box.text("bottom"),
+        Box.border("rounded", { annotation: Ansi.green })
+      );
+      const result: Box.Box<AnsiStyle> = Box.vAppend(plain, styled);
+      expect(result.rows).toBeGreaterThan(0);
+    });
+
+    it("pipe composition with mixed annotation types", () => {
+      const result = pipe(
+        Box.text("content"),
+        Box.moveRight(2),
+        Box.border("rounded", { annotation: Ansi.green }),
+        Box.moveDown(1)
+      );
+      expect(result.rows).toBeGreaterThan(0);
+    });
+  });
 });


### PR DESCRIPTION
## Goal/Scope

There is an issue with annotations not being able to be mixes as a result of invariance.  Will like to explore how to add covariance similar to how Effect core does this.

## Description

Add variance annotation (out A) and Types.Covariant<A> phantom marker
to the Box interface, matching the pattern used by Effect's own types.

Update hAppend, vAppend, hcatWithSpace, vcatWithSpace, and border
signatures to accept mixed annotation types (<A, B> => Box<A | B>),
enabling natural composition of plain and annotated boxes.

Add covariance tests to box.test.ts covering type widening, mixed-type
combinators, and generic pipeline usage.
