### PR TITLE
fix: resolve exactOptionalPropertyTypes error in autoGrid

### DIFF
--- a/.changeset/mighty-places-attack.md
+++ b/.changeset/mighty-places-attack.md
@@ -1,0 +1,5 @@
+---
+"effect-boxes": patch
+---
+
+resolve exactOptionalPropertyTypes error in autoGrid

--- a/src/internal/grid.ts
+++ b/src/internal/grid.ts
@@ -92,8 +92,8 @@ export const auto = dual<
       cols,
       colWidth,
       gap: [gap, 0],
-      align: options.align,
-      stretch: options.stretch,
+      ...(options.align !== undefined && { align: options.align }),
+      ...(options.stretch !== undefined && { stretch: options.stretch }),
     });
   }
 );

--- a/tests/layout.test.ts
+++ b/tests/layout.test.ts
@@ -216,6 +216,25 @@ describe("Grid.auto", () => {
     const result = Grid.auto(items, 100, { minColWidth: 10, maxColWidth: 20 });
     expect(Box.cols(result)).toBeLessThanOrEqual(100);
   });
+
+  it("works without optional align or stretch", () => {
+    const items = ["A", "B", "C", "D"].map(Box.text);
+    const result = Grid.auto(items, 30, { minColWidth: 10 });
+    expect(Box.rows(result)).toBeGreaterThan(0);
+    expect(Box.cols(result)).toBeGreaterThan(0);
+  });
+
+  it("works with explicit align option", () => {
+    const items = ["A", "B", "C", "D"].map(Box.text);
+    const result = Grid.auto(items, 30, { minColWidth: 10, align: Box.center1 });
+    expect(Box.rows(result)).toBeGreaterThan(0);
+  });
+
+  it("works with explicit stretch option", () => {
+    const items = ["A", "B", "C", "D"].map(Box.text);
+    const result = Grid.auto(items, 30, { minColWidth: 10, stretch: true });
+    expect(Box.rows(result)).toBeGreaterThan(0);
+  });
 });
 
 // ─── Render snapshot tests ───────────────────────────────────────────────────


### PR DESCRIPTION
- Fix `exactOptionalPropertyTypes` TypeScript error in `autoGrid`  
- Adjust typings to correctly handle optional props and align with strict optional property semantics