### PR TITLE
fix: `Box.truncate` stack overflow when truncating wide row layouts.

### DIFF
--- a/.changeset/true-llamas-give.md
+++ b/.changeset/true-llamas-give.md
@@ -1,0 +1,5 @@
+---
+"effect-boxes": patch
+---
+
+fix `Box.truncate` stack overflow when truncating wide row layouts.

--- a/packages/effect-boxes/src/internal/box.ts
+++ b/packages/effect-boxes/src/internal/box.ts
@@ -1212,13 +1212,12 @@ const truncateWidth = <A>(
       blank: () => emptyBox(box.rows, width),
       text: (t) => onText(t),
       row: () =>
-        go(
-          make({
-            rows: box.rows,
-            cols: box.cols,
-            content: { _tag: "SubBox", xAlign: left, yAlign: top, box },
-          })
-        ),
+        make({
+          rows: box.rows,
+          cols: width,
+          content: { _tag: "SubBox", xAlign: left, yAlign: top, box },
+          annotation: box.annotation,
+        }),
       col: (boxes) =>
         make({
           rows: box.rows,

--- a/packages/effect-boxes/tests/truncate.test.ts
+++ b/packages/effect-boxes/tests/truncate.test.ts
@@ -195,6 +195,16 @@ describe("Box.truncate", () => {
   // ---------------------------------------------------------------------------
 
   describe("composition", () => {
+    it("does not recurse infinitely when truncating a wide row", () => {
+      const row = Box.hcat(
+        [Box.text("left panel"), Box.text("right panel")],
+        Box.top
+      );
+
+      expect(() => pipe(row, Box.truncate(8, Box.left))).not.toThrow();
+      expect(pipe(row, Box.truncate(8, Box.left)).cols).toBe(8);
+    });
+
     it("works with hcat after truncation", () => {
       const left = pipe(Box.text("Long left text"), Box.truncate(8, Box.left));
       const right = Box.text("Right");


### PR DESCRIPTION
Fix stack overflow in `Box.truncate` when truncating wide row layouts.

- closes #87