### PR TITLE
feat: add crop transformers

### DIFF
--- a/.changeset/clear-bugs-push.md
+++ b/.changeset/clear-bugs-push.md
@@ -1,0 +1,7 @@
+---
+"effect-boxes": minor
+---
+
+add `Box.cropWidth` and `Box.cropHeight` for viewport-style cropping.
+
+Transformer that allow callers to crop boxes from an arbitrary horizontal or vertical offset, making it possible to render scrollable 2D viewports without pre-rendering to strings.

--- a/apps/docs/app/content/api/box.mdx
+++ b/apps/docs/app/content/api/box.mdx
@@ -1143,6 +1143,55 @@ import * as Ansi from "effect-boxes/Ansi";
 const coloredBox = Box.annotate(Box.text("Hello World"), Ansi.red);
 ```
 
+### cropHeight
+
+Crops a box vertically, keeping up to `height` rows after `offset`.
+
+**Signature**
+
+```ts
+export declare const cropHeight: {
+  (offset: number, height: number): <A>(self: Box<A>) => Box<A>;
+  <A>(self: Box<A>, offset: number, height: number): Box<A>;
+};
+```
+
+**Example**
+
+```typescript
+import { pipe } from "effect";
+import * as Box from "effect-boxes/Box";
+
+const result = pipe(Box.text("A\nB\nC\nD"), Box.cropHeight(1, 2));
+console.log(Box.renderPlainSync(result));
+// B
+// C
+```
+
+### cropWidth
+
+Crops a box horizontally, keeping up to `width` columns after `offset`.
+
+**Signature**
+
+```ts
+export declare const cropWidth: {
+  (offset: number, width: number): <A>(self: Box<A>) => Box<A>;
+  <A>(self: Box<A>, offset: number, width: number): Box<A>;
+};
+```
+
+**Example**
+
+```typescript
+import { pipe } from "effect";
+import * as Box from "effect-boxes/Box";
+
+const result = pipe(Box.text("Hello World"), Box.cropWidth(6, 5));
+console.log(Box.renderPlainSync(result));
+// World
+```
+
 ### maxHeight
 
 Caps a box at `n` rows tall, keeping only the first `n` rows.

--- a/apps/scratchpad/00-index.ts
+++ b/apps/scratchpad/00-index.ts
@@ -60,7 +60,7 @@ const demos = [
     title: "9. Log Viewer",
     value: "log-viewer",
     description:
-      "Scrollable stream log viewer with truncate, minWidth, maxWidth, maxHeight",
+      "Scrollable stream log viewer with cropWidth, cropHeight, and sizing constraints",
   },
   {
     title: "10. Layout Combinators",

--- a/apps/scratchpad/09-log-viewer.ts
+++ b/apps/scratchpad/09-log-viewer.ts
@@ -64,27 +64,23 @@ const renderLayout = (
 
     // Compute visible window
     const totalLines = state.lines.length;
-    const visibleLines = state.lines.slice(
-      state.scrollOffset,
-      state.scrollOffset + height
-    );
 
     // Build content box
     const contentBox =
-      visibleLines.length === 0
+      state.lines.length === 0
         ? Box.text("Waiting for log data...").pipe(Box.annotate(Ansi.dim))
         : pipe(
-            visibleLines.map((entry) => renderLogLine(entry)),
+            state.lines.map((entry) => renderLogLine(entry)),
             (boxes) => Box.vcat(boxes, Box.left)
           );
 
-    // Apply constraints: fixed height, max width with truncation
+    // Apply constraints: fixed-height viewport and left-edge horizontal crop.
     const constrainedContent = pipe(
       contentBox,
+      Box.cropHeight(state.scrollOffset, height),
       Box.minHeight(height),
-      Box.maxHeight(height),
-      Box.minWidth(innerWidth),
-      Box.truncate(innerWidth, Box.left)
+      Box.cropWidth(0, innerWidth),
+      Box.minWidth(innerWidth)
     );
 
     // Header

--- a/packages/effect-boxes/src/Box.ts
+++ b/packages/effect-boxes/src/Box.ts
@@ -1736,6 +1736,26 @@ export const maxWidth: {
 } = internal.maxWidth;
 
 /**
+ * Crops a box horizontally, keeping up to `width` columns after `offset`.
+ *
+ * @example
+ * ```typescript
+ * import { pipe } from "effect"
+ * import * as Box from "effect-boxes/Box"
+ *
+ * const result = pipe(Box.text("Hello World"), Box.cropWidth(6, 5))
+ * console.log(Box.renderPlainSync(result))
+ * // World
+ * ```
+ *
+ * @category transformations
+ */
+export const cropWidth: {
+  (offset: number, width: number): <A>(self: Box<A>) => Box<A>;
+  <A>(self: Box<A>, offset: number, width: number): Box<A>;
+} = internal.cropWidth;
+
+/**
  * Ensures a box is at least `n` rows tall, padding with blank rows at the
  * bottom if the box is shorter.
  *
@@ -1775,3 +1795,24 @@ export const maxHeight: {
   (n: number): <A>(self: Box<A>) => Box<A>;
   <A>(self: Box<A>, n: number): Box<A>;
 } = internal.maxHeight;
+
+/**
+ * Crops a box vertically, keeping up to `height` rows after `offset`.
+ *
+ * @example
+ * ```typescript
+ * import { pipe } from "effect"
+ * import * as Box from "effect-boxes/Box"
+ *
+ * const result = pipe(Box.text("A\nB\nC\nD"), Box.cropHeight(1, 2))
+ * console.log(Box.renderPlainSync(result))
+ * // B
+ * // C
+ * ```
+ *
+ * @category transformations
+ */
+export const cropHeight: {
+  (offset: number, height: number): <A>(self: Box<A>) => Box<A>;
+  <A>(self: Box<A>, offset: number, height: number): Box<A>;
+} = internal.cropHeight;

--- a/packages/effect-boxes/src/internal/box.ts
+++ b/packages/effect-boxes/src/internal/box.ts
@@ -1246,6 +1246,214 @@ const truncateWidth = <A>(
   return result;
 };
 
+const cropLine = (text: string, offset: number, width: number): string => {
+  const start = Math.max(0, offset);
+  const end = start + Math.max(0, width);
+  let column = 0;
+  const result: string[] = [];
+
+  for (const segment of Width.segments(text)) {
+    const segmentWidth = Width.ofString(segment);
+    const nextColumn = column + segmentWidth;
+
+    if (column >= start && nextColumn <= end) {
+      result.push(segment);
+    }
+
+    column = nextColumn;
+    if (column >= end) {
+      break;
+    }
+  }
+
+  return result.join("");
+};
+
+const preserveAnnotation = <A>(
+  self: Box.Box<A>,
+  that: Box.Box<A>
+): Box.Box<A> =>
+  self.annotation && !that.annotation
+    ? make({
+        rows: that.rows,
+        cols: that.cols,
+        content: that.content,
+        annotation: self.annotation,
+      })
+    : that;
+
+/** @internal */
+export const cropWidth = dual<
+  (offset: number, width: number) => <A>(self: Box.Box<A>) => Box.Box<A>,
+  <A>(self: Box.Box<A>, offset: number, width: number) => Box.Box<A>
+>(3, <A>(self: Box.Box<A>, offset: number, width: number): Box.Box<A> => {
+  const start = Math.max(0, offset);
+  const targetWidth = Math.min(
+    Math.max(0, width),
+    Math.max(0, self.cols - start)
+  );
+
+  if (start === 0 && self.cols <= targetWidth) return self;
+
+  const go = (
+    box: Box.Box<A>,
+    columnOffset: number,
+    columnsToKeep: number
+  ): Box.Box<A> =>
+    match(box, {
+      blank: () =>
+        preserveAnnotation(
+          box,
+          emptyBox(
+            box.rows,
+            Math.min(columnsToKeep, Math.max(0, box.cols - columnOffset))
+          )
+        ),
+      text: (text) =>
+        preserveAnnotation(
+          box,
+          unsafeLine(cropLine(text, columnOffset, columnsToKeep))
+        ),
+      row: (boxes) => {
+        const cropped: Box.Box<A>[] = [];
+        let skipped = columnOffset;
+        let remaining = columnsToKeep;
+
+        for (const child of boxes) {
+          if (remaining <= 0) break;
+          if (skipped >= child.cols) {
+            skipped -= child.cols;
+            continue;
+          }
+
+          const childCols = Math.min(remaining, child.cols - skipped);
+          cropped.push(go(child, skipped, childCols));
+          remaining -= childCols;
+          skipped = 0;
+        }
+
+        return cropped.length === 0
+          ? emptyBox(box.rows, columnsToKeep)
+          : hcat(cropped, top);
+      },
+      col: (boxes) =>
+        make({
+          rows: box.rows,
+          cols: columnsToKeep,
+          content: {
+            _tag: "Col",
+            boxes: boxes.map((child) => go(child, columnOffset, columnsToKeep)),
+          },
+          annotation: box.annotation,
+        }),
+      subBox: (inner, xAlign, yAlign) =>
+        make({
+          rows: box.rows,
+          cols: columnsToKeep,
+          content: {
+            _tag: "SubBox",
+            xAlign,
+            yAlign,
+            box: go(inner, columnOffset, columnsToKeep),
+          },
+          annotation: box.annotation,
+        }),
+    });
+
+  const result = go(self, start, targetWidth);
+  return preserveAnnotation(self, result);
+});
+
+const cropHeightInternal = <A>(
+  self: Box.Box<A>,
+  offset: number,
+  height: number
+): Box.Box<A> => {
+  const start = Math.max(0, offset);
+  const targetHeight = Math.min(
+    Math.max(0, height),
+    Math.max(0, self.rows - start)
+  );
+
+  if (start === 0 && self.rows <= targetHeight) return self;
+
+  const go = (
+    box: Box.Box<A>,
+    rowOffset: number,
+    rowsToKeep: number
+  ): Box.Box<A> =>
+    match(box, {
+      blank: () =>
+        preserveAnnotation(
+          box,
+          emptyBox(
+            Math.min(rowsToKeep, Math.max(0, box.rows - rowOffset)),
+            box.cols
+          )
+        ),
+      text: () =>
+        rowOffset === 0 && rowsToKeep > 0 ? box : emptyBox(0, box.cols),
+      row: (boxes) =>
+        make({
+          rows: rowsToKeep,
+          cols: box.cols,
+          content: {
+            _tag: "Row",
+            boxes: boxes.map((child) => go(child, rowOffset, rowsToKeep)),
+          },
+          annotation: box.annotation,
+        }),
+      col: (boxes) => {
+        const cropped: Box.Box<A>[] = [];
+        let skipped = rowOffset;
+        let remaining = rowsToKeep;
+
+        for (const child of boxes) {
+          if (remaining <= 0) break;
+          if (skipped >= child.rows) {
+            skipped -= child.rows;
+            continue;
+          }
+
+          const childRows = Math.min(remaining, child.rows - skipped);
+          cropped.push(go(child, skipped, childRows));
+          remaining -= childRows;
+          skipped = 0;
+        }
+
+        return cropped.length === 0
+          ? emptyBox(rowsToKeep, box.cols)
+          : make({
+              rows: rowsToKeep,
+              cols: box.cols,
+              content: { _tag: "Col", boxes: cropped },
+              annotation: box.annotation,
+            });
+      },
+      subBox: (inner, xAlign, yAlign) =>
+        make({
+          rows: rowsToKeep,
+          cols: box.cols,
+          content: {
+            _tag: "SubBox",
+            xAlign,
+            yAlign,
+            box: go(inner, rowOffset, rowsToKeep),
+          },
+          annotation: box.annotation,
+        }),
+    });
+
+  const result = go(self, start, targetHeight);
+  return preserveAnnotation(self, result);
+};
+
+/** @internal */
+export const cropHeight = dual<
+  (offset: number, height: number) => <A>(self: Box.Box<A>) => Box.Box<A>,
+  <A>(self: Box.Box<A>, offset: number, height: number) => Box.Box<A>
+>(3, cropHeightInternal);
+
 /** @internal */
 export const truncate = dual<
   (width: number, pos: Box.Alignment) => <A>(self: Box.Box<A>) => Box.Box<A>,

--- a/packages/effect-boxes/tests/constraints.test.ts
+++ b/packages/effect-boxes/tests/constraints.test.ts
@@ -1,5 +1,6 @@
 import { pipe } from "effect";
 import { describe, expect, it } from "vitest";
+import * as Ansi from "../src/Ansi";
 import * as Box from "../src/Box";
 
 /** Replace spaces with dots for visible whitespace in assertions */
@@ -71,6 +72,69 @@ describe("Box.maxWidth", () => {
   });
 });
 
+describe("Box.cropWidth", () => {
+  it("crops a horizontal window from text", () => {
+    const result = pipe(Box.text("Hello World"), Box.cropWidth(6, 5));
+    expect(Box.cols(result)).toBe(5);
+    expect(Box.renderPlainSync(result)).toBe("World");
+  });
+
+  it("crops each line of a multi-line box", () => {
+    const result = pipe(Box.text("abcdef\n123456"), Box.cropWidth(2, 3));
+    expect(Box.cols(result)).toBe(3);
+    expect(Box.rows(result)).toBe(2);
+    expect(Box.renderPlainSync(result)).toBe("cde\n345");
+  });
+
+  it("is a maxWidth equivalent for non-positive offsets", () => {
+    const result = pipe(Box.text("Hello"), Box.cropWidth(-2, 3));
+    expect(Box.renderPlainSync(result)).toBe("Hel");
+  });
+
+  it("returns zero width when offset is beyond the box", () => {
+    const result = pipe(Box.text("Hello\nWorld"), Box.cropWidth(20, 5));
+    expect(Box.cols(result)).toBe(0);
+    expect(Box.rows(result)).toBe(2);
+    expect(Box.renderPlainSync(result)).toBe("\n");
+  });
+
+  it("does not split wide characters at crop boundaries", () => {
+    const result = pipe(Box.text("a界b"), Box.cropWidth(1, 1));
+    expect(Box.cols(result)).toBe(1);
+    expect(Box.renderPlainSync(result)).toBe(" ");
+  });
+
+  it("crops through horizontally composed boxes", () => {
+    const result = pipe(
+      Box.hcat([Box.text("ABC"), Box.text("DEF")], Box.top),
+      Box.cropWidth(2, 3)
+    );
+    expect(Box.renderPlainSync(result)).toBe("CDE");
+  });
+
+  it("preserves nested annotations when cropping horizontally composed boxes", () => {
+    const result = pipe(
+      Box.hcat(
+        [
+          Box.text("INFO ").pipe(Box.annotate(Ansi.cyan)),
+          Box.text("message").pipe(Box.annotate(Ansi.red)),
+        ],
+        Box.top
+      ),
+      Box.cropWidth(3, 6)
+    );
+
+    expect(Box.renderPlainSync(result)).toBe("O mess");
+    expect(Box.renderPrettySync(result)).toContain("\x1b[36mO ");
+    expect(Box.renderPrettySync(result)).toContain("\x1b[31mmess");
+  });
+
+  it("supports data-first usage", () => {
+    const result = Box.cropWidth(Box.text("Hello World"), 6, 5);
+    expect(Box.renderPlainSync(result)).toBe("World");
+  });
+});
+
 describe("Box.minHeight", () => {
   it("pads a short box to the target height", () => {
     const result = pipe(Box.text("X"), Box.minHeight(5));
@@ -123,6 +187,77 @@ describe("Box.maxHeight", () => {
   it("supports data-first usage", () => {
     const result = Box.maxHeight(Box.text("A\nB\nC\nD\nE"), 2);
     expect(Box.rows(result)).toBe(2);
+  });
+});
+
+describe("Box.cropHeight", () => {
+  it("crops a vertical window from text", () => {
+    const result = pipe(Box.text("A\nB\nC\nD"), Box.cropHeight(1, 2));
+    expect(Box.rows(result)).toBe(2);
+    expect(Box.cols(result)).toBe(1);
+    expect(Box.renderPlainSync(result)).toBe("B\nC");
+  });
+
+  it("is a maxHeight equivalent for non-positive offsets", () => {
+    const result = pipe(Box.text("A\nB\nC"), Box.cropHeight(-1, 2));
+    expect(Box.renderPlainSync(result)).toBe("A\nB");
+  });
+
+  it("returns zero height when offset is beyond the box", () => {
+    const result = pipe(Box.text("A\nB"), Box.cropHeight(5, 2));
+    expect(Box.rows(result)).toBe(0);
+    expect(Box.cols(result)).toBe(1);
+    expect(Box.renderPlainSync(result)).toBe("");
+  });
+
+  it("crops through vertically composed boxes", () => {
+    const result = pipe(
+      Box.vcat([Box.text("A\nB"), Box.text("C\nD")], Box.left),
+      Box.cropHeight(1, 2)
+    );
+    expect(Box.renderPlainSync(result)).toBe("B\nC");
+  });
+
+  it("preserves nested annotations through fixed-size viewport crops", () => {
+    const makeLine = (timestamp: string, level: string, message: string) => {
+      const style = level === "WARN" ? Ansi.yellow : Ansi.cyan;
+      return Box.hsep(
+        [
+          Box.text(timestamp).pipe(Box.annotate(Ansi.dim)),
+          Box.text("●").pipe(Box.annotate(style)),
+          Box.text(level.padEnd(5)).pipe(Box.annotate(style)),
+          Box.text(message).pipe(Box.annotate(style)),
+        ],
+        1,
+        Box.top
+      );
+    };
+
+    const result = pipe(
+      Box.vcat(
+        [
+          makeLine("00:01.1", "INFO", "first"),
+          makeLine("00:03.0", "WARN", "Redis connection slow"),
+        ],
+        Box.left
+      ),
+      Box.cropHeight(1, 1),
+      Box.minHeight(2),
+      Box.cropWidth(0, 40),
+      Box.minWidth(40)
+    );
+
+    const pretty = Box.renderPrettySync(result);
+    expect(Box.renderPlainSync(result)).toContain("00:03.0 ● WARN  Redis");
+    expect(pretty).toContain("\x1b[2m00:03.0\x1b[0m");
+    expect(pretty).toContain("\x1b[33m●\x1b[0m");
+    expect(pretty).toContain("\x1b[33mWARN \x1b[0m");
+    expect(pretty).toContain("\x1b[33mRedis connection slow\x1b[0m");
+  });
+
+  it("supports data-first usage", () => {
+    const result = Box.cropHeight(Box.text("A\nB\nC\nD"), 1, 2);
+    expect(Box.renderPlainSync(result)).toBe("B\nC");
   });
 });
 


### PR DESCRIPTION
## Goal/Scope
Add crop transformers to enable cropping operations in the transformers pipeline

- Refactor to use crop integration with the log viewer for improved handling/visibility

---

- [x] closes #62